### PR TITLE
feat: Define Protobuf contracts for PatchService and PlayerService

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,9 @@ Instructions for AI agents (Claude Code, Copilot, Cursor, etc.) working on this 
 - Run `buf lint` before committing any `.proto` changes.
 - Run `buf generate` after modifying protos to regenerate Go + TypeScript code.
 - Never hand-edit files in `backend/gen/` or `frontend/src/gen/`.
+- The `apiName` field is the universal join key across CommunityDragon and Riot API data.
+- Two services defined: `PatchService` (static game data) and `PlayerService` (player data).
+- See `docs/DATA_SOURCES.md` for the complete field mapping from external sources to proto messages.
 
 ### SQL (migrations/, backend/sqlc/)
 
@@ -70,6 +73,8 @@ Instructions for AI agents (Claude Code, Copilot, Cursor, etc.) working on this 
 ## Project Context
 
 - Full spec: `docs/SPEC.md` (Portuguese)
+- Data source mapping: `docs/DATA_SOURCES.md` (CommunityDragon, Riot API, Scrapers)
 - Architecture and commands: `CLAUDE.md`
-- 4 development phases tracked via GitHub milestones (#1-#24)
+- Protobuf contracts: `proto/tft/v1/patch.proto`, `proto/tft/v1/player.proto`
+- 4 development phases tracked via GitHub milestones (#1-#30)
 - Target: ~50MB RAM, zero FPS impact during TFT gameplay

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,22 +39,25 @@ TFT Oracle is an ultra-lightweight desktop app (~50MB RAM) that acts as an AI-po
 | Data sync | CommunityDragon | Game data (champions, items, traits) |
 | Crawler | Go (Goroutines) | MetaTFT, TFTactics, Mobalytics (Phase 4) |
 
-## Project Structure (planned)
+## Project Structure
 
 ```
 tft-oracle/
 ├── proto/                  # Protobuf contracts (.proto files)
+│   └── tft/v1/
+│       ├── patch.proto     # PatchService — champions, items, traits (CommunityDragon)
+│       └── player.proto    # PlayerService — profile, ranked, match history (Riot API)
 ├── backend/                # Go backend (Connect RPC server)
 │   ├── cmd/server/         # Entry point
 │   ├── internal/           # Business logic
-│   ├── gen/                # Generated protobuf code
+│   ├── gen/                # Generated protobuf code (gitignored)
 │   └── sqlc/               # Generated SQL queries
 ├── frontend/               # React + Vite app
 │   ├── src/
 │   │   ├── components/     # UI components
 │   │   ├── hooks/          # Custom hooks
 │   │   ├── stores/         # Zustand stores
-│   │   └── gen/            # Generated Connect-Query hooks
+│   │   └── gen/            # Generated Connect-Query hooks (gitignored)
 │   └── index.html
 ├── src-tauri/              # Tauri v2 Rust shell
 ├── migrations/             # PostgreSQL migrations
@@ -138,9 +141,33 @@ sqlc generate                               # Generate Go from SQL queries
 - **Out of MVP scope**: No memory/screen reading (Vanguard anti-cheat risk), no auto lobby detection (manual Riot ID), no deterministic combat sim (AI heuristics instead)
 - **Security**: Never commit API keys (.env files). Riot API key, OpenAI key, and DB credentials go in environment variables only.
 
+## Data Architecture
+
+The `apiName` field is the universal join key across all data sources:
+
+| CommunityDragon | Riot API | Join |
+|-----------------|----------|------|
+| `Champion.api_name` | `MatchUnit.character_id` | Champion identity |
+| `Item.api_name` | `MatchUnit.item_names[]` | Item identity |
+| `Trait.api_name` | `MatchTrait.api_name` | Trait identity |
+| Augment `api_name` (in items) | `Participant.augments[]` | Augment identity |
+
+### Protobuf Services
+
+| Service | Proto | Phase | Data Source |
+|---------|-------|-------|-------------|
+| `PatchService.GetPatchData` | `proto/tft/v1/patch.proto` | 1 | CommunityDragon |
+| `PlayerService.GetPlayerProfile` | `proto/tft/v1/player.proto` | 2 | Riot API |
+| `PlayerService.GetMatchHistory` | `proto/tft/v1/player.proto` | 2 | Riot API |
+
 ## Key Files
 
 - `docs/SPEC.md` — Full technical specification (Portuguese)
+- `docs/DATA_SOURCES.md` — Complete external data source mapping (CommunityDragon, Riot API, Scrapers)
+- `proto/tft/v1/patch.proto` — PatchService contract (champions, items, traits)
+- `proto/tft/v1/player.proto` — PlayerService contract (profile, ranked, matches)
+- `buf.yaml` / `buf.gen.yaml` — Buf configuration for code generation
+- `Taskfile.yml` — Task runner (generate, lint, dev, build)
 - `.github/ISSUE_TEMPLATE/` — Bug report and feature request templates
 - `.github/pull_request_template.md` — PR template with checklist
 - `.github/CONTRIBUTING.md` — Contribution guide with conventions

--- a/proto/tft/v1/patch.proto
+++ b/proto/tft/v1/patch.proto
@@ -1,0 +1,111 @@
+syntax = "proto3";
+
+package tft.v1;
+
+// PatchService provides static game data synchronized from CommunityDragon.
+// Source: https://raw.communitydragon.org/latest/cdragon/tft/{locale}.json
+service PatchService {
+  // GetPatchData returns the current patch data: champions, items, traits, and augments.
+  rpc GetPatchData(GetPatchDataRequest) returns (GetPatchDataResponse);
+}
+
+message GetPatchDataRequest {
+  // TFT set number. 0 or omitted = latest set.
+  int32 set_number = 1;
+  // Locale for localized names/descriptions (e.g. "en_us", "pt_br"). Default: "en_us".
+  string locale = 2;
+}
+
+message GetPatchDataResponse {
+  SetMetadata set = 1;
+  repeated Champion champions = 2;
+  repeated Item items = 3;
+  repeated Trait traits = 4;
+}
+
+// --- Set Metadata ---
+
+message SetMetadata {
+  int32 number = 1;
+  string name = 2;
+  string mutator = 3;
+}
+
+// --- Champion ---
+
+message Champion {
+  // Unique identifier, used as join key with Riot API UnitDTO.characterId.
+  string api_name = 1;
+  string name = 2;
+  int32 cost = 3;
+  string role = 4;
+  // Trait apiNames this champion belongs to.
+  repeated string trait_api_names = 5;
+  ChampionStats stats = 6;
+  ChampionAbility ability = 7;
+  string icon_url = 8;
+  string square_icon_url = 9;
+  string tile_icon_url = 10;
+}
+
+message ChampionStats {
+  double hp = 1;
+  double armor = 2;
+  double magic_resist = 3;
+  double damage = 4;
+  double attack_speed = 5;
+  double range = 6;
+  int32 mana = 7;
+  double initial_mana = 8;
+  double crit_chance = 9;
+  double crit_multiplier = 10;
+}
+
+message ChampionAbility {
+  string name = 1;
+  string desc = 2;
+  string icon_url = 3;
+  repeated AbilityVariable variables = 4;
+}
+
+message AbilityVariable {
+  string name = 1;
+  // Values per star level (index 0 = base, 1 = 1-star, 2 = 2-star, 3 = 3-star).
+  repeated double values = 2;
+}
+
+// --- Item ---
+
+message Item {
+  // Unique identifier, used as join key with Riot API UnitDTO.itemNames.
+  string api_name = 1;
+  string name = 2;
+  string desc = 3;
+  // Empty for base components, two apiNames for crafted items.
+  repeated string composition = 4;
+  map<string, double> effects = 5;
+  string icon_url = 6;
+  repeated string associated_traits = 7;
+  repeated string incompatible_traits = 8;
+  repeated string tags = 9;
+  bool unique = 10;
+}
+
+// --- Trait ---
+
+message Trait {
+  // Unique identifier, used as join key with Riot API TraitDTO.name.
+  string api_name = 1;
+  string name = 2;
+  string desc = 3;
+  string icon_url = 4;
+  repeated TraitEffect effects = 5;
+}
+
+message TraitEffect {
+  int32 min_units = 1;
+  int32 max_units = 2;
+  // 0 = inactive, 1 = bronze, 2 = silver, 3 = gold, 4 = chromatic.
+  int32 style = 3;
+  map<string, double> variables = 4;
+}

--- a/proto/tft/v1/player.proto
+++ b/proto/tft/v1/player.proto
@@ -1,0 +1,158 @@
+syntax = "proto3";
+
+package tft.v1;
+
+// PlayerService provides player-specific data from the Riot Games API.
+// Requires RIOT_API_KEY environment variable.
+service PlayerService {
+  // GetPlayerProfile returns account, summoner, and ranked data for a Riot ID.
+  rpc GetPlayerProfile(GetPlayerProfileRequest) returns (GetPlayerProfileResponse);
+  // GetMatchHistory returns recent match history for a player.
+  rpc GetMatchHistory(GetMatchHistoryRequest) returns (GetMatchHistoryResponse);
+}
+
+// --- GetPlayerProfile ---
+
+message GetPlayerProfileRequest {
+  // Riot ID game name (e.g. "MeninoNias").
+  string game_name = 1;
+  // Riot ID tag line (e.g. "BR1").
+  string tag_line = 2;
+  // Riot routing region: "americas", "europe", "asia".
+  string region = 3;
+}
+
+message GetPlayerProfileResponse {
+  Account account = 1;
+  Summoner summoner = 2;
+  repeated RankedEntry ranked_entries = 3;
+}
+
+message Account {
+  string puuid = 1;
+  string game_name = 2;
+  string tag_line = 3;
+}
+
+message Summoner {
+  string id = 1;
+  string puuid = 2;
+  int32 profile_icon_id = 3;
+  int64 summoner_level = 4;
+  int64 revision_date = 5;
+}
+
+message RankedEntry {
+  // Queue type: "RANKED_TFT", "RANKED_TFT_TURBO", etc.
+  string queue_type = 1;
+  // Tier: "IRON", "BRONZE", "SILVER", ..., "CHALLENGER".
+  string tier = 2;
+  // Division: "I", "II", "III", "IV".
+  string rank = 3;
+  int32 league_points = 4;
+  int32 wins = 5;
+  int32 losses = 6;
+  bool hot_streak = 7;
+  bool veteran = 8;
+  bool fresh_blood = 9;
+  bool inactive = 10;
+  optional MiniSeries mini_series = 11;
+}
+
+message MiniSeries {
+  string progress = 1;
+  int32 wins = 2;
+  int32 losses = 3;
+  int32 target = 4;
+}
+
+// --- GetMatchHistory ---
+
+message GetMatchHistoryRequest {
+  string puuid = 1;
+  // Riot routing region: "americas", "europe", "asia".
+  string region = 2;
+  // Max matches to return (default 20, max 200).
+  int32 count = 3;
+  // Pagination offset (0-based).
+  int32 start = 4;
+}
+
+message GetMatchHistoryResponse {
+  repeated Match matches = 1;
+}
+
+message Match {
+  MatchMetadata metadata = 1;
+  MatchInfo info = 2;
+}
+
+message MatchMetadata {
+  string data_version = 1;
+  string match_id = 2;
+  // PUUIDs of all 8 participants.
+  repeated string participant_puuids = 3;
+}
+
+message MatchInfo {
+  int64 game_datetime = 1;
+  float game_length = 2;
+  string game_version = 3;
+  string game_variation = 4;
+  int32 queue_id = 5;
+  int32 tft_set_number = 6;
+  string tft_set_core_name = 7;
+  string tft_game_type = 8;
+  string end_of_game_result = 9;
+  repeated Participant participants = 10;
+}
+
+message Participant {
+  string puuid = 1;
+  // Final placement (1-8).
+  int32 placement = 2;
+  int32 level = 3;
+  int32 gold_left = 4;
+  int32 last_round = 5;
+  float time_eliminated = 6;
+  int32 total_damage_to_players = 7;
+  int32 players_eliminated = 8;
+  // Double Up partner group (-1 if solo).
+  int32 partner_group_id = 9;
+  // Augment apiNames (join key with Item.api_name where tag contains augment).
+  repeated string augments = 10;
+  Companion companion = 11;
+  repeated MatchTrait traits = 12;
+  repeated MatchUnit units = 13;
+}
+
+message Companion {
+  string content_id = 1;
+  string species = 2;
+  int32 item_id = 3;
+  int32 skin_id = 4;
+}
+
+message MatchTrait {
+  // Trait apiName (join key with Trait.api_name from PatchService).
+  string api_name = 1;
+  int32 num_units = 2;
+  // 0 = inactive, 1 = bronze, 2 = silver, 3 = gold, 4 = chromatic.
+  int32 style = 3;
+  int32 tier_current = 4;
+  int32 tier_total = 5;
+}
+
+message MatchUnit {
+  // Champion apiName (join key with Champion.api_name from PatchService).
+  string character_id = 1;
+  string name = 2;
+  // Star level (1-3).
+  int32 tier = 3;
+  // Cost tier (0 = 1-cost, 4 = 5-cost).
+  int32 rarity = 4;
+  // Item numeric IDs.
+  repeated int32 item_ids = 5;
+  // Item apiNames (join key with Item.api_name from PatchService).
+  repeated string item_names = 6;
+}


### PR DESCRIPTION
## Summary

- **`proto/tft/v1/patch.proto`** — `PatchService.GetPatchData` returning champions, items, traits, and set metadata from CommunityDragon
- **`proto/tft/v1/player.proto`** — `PlayerService.GetPlayerProfile` (account, summoner, ranked) and `PlayerService.GetMatchHistory` (full match details with compositions, units, traits, augments) from Riot API
- Updated **CLAUDE.md** with Data Architecture section (apiName join key mapping, Protobuf services table, updated project structure and key files)
- Updated **AGENTS.md** with proto-specific guidance and project context references

## Data Architecture

All messages use `apiName` as the universal join key:

| CommunityDragon | Riot API | Join |
|---|---|---|
| `Champion.api_name` | `MatchUnit.character_id` | Champion identity |
| `Item.api_name` | `MatchUnit.item_names[]` | Item identity |
| `Trait.api_name` | `MatchTrait.api_name` | Trait identity |
| Augment `api_name` | `Participant.augments[]` | Augment identity |

## Acceptance Criteria (from #1)

- [x] `.proto` files created with proper message definitions
- [x] Buf configuration set up (`buf.yaml`, `buf.gen.yaml`) — already existed
- [ ] Go server stubs generated via `buf generate` — requires Go + buf install (#20, #6)
- [ ] TypeScript/React client hooks auto-generated — requires frontend setup (#4)
- [ ] Basic request/response works end-to-end — requires backend + frontend (#5, #6)

> Proto contracts are ready. Code generation and e2e depend on #4 and #6.

## Validation

- `buf lint` passes with zero errors (verified via Docker)

## Test plan

- [x] `buf lint` passes
- [ ] `buf generate` produces Go stubs (blocked on Go install — #20)
- [ ] `buf generate` produces TS hooks (blocked on frontend setup — #4)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)