### PR TITLE
docs: Add Architecture Decision Records (ADRs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,9 @@ Instructions for AI agents (Claude Code, Copilot, Cursor, etc.) working on this 
 - All DB access goes through sqlc — never write raw SQL in Go.
 - Use `internal/` packages for business logic. Keep `cmd/` thin.
 - Wrap errors with context: `fmt.Errorf("fetchChampions: %w", err)`.
-- Use Connect RPC handlers, not raw HTTP handlers.
+- Use Connect RPC handlers, not raw HTTP handlers. Connect RPC speaks HTTP+JSON (not raw gRPC) so the browser/webview can call it directly.
 - Protobuf types are the API contract — do not create parallel DTOs.
+- No ORMs (GORM, etc.) — sqlc generates type-safe Go from raw SQL. Zero reflection, zero runtime overhead.
 
 ### TypeScript/React (frontend/)
 
@@ -61,9 +62,11 @@ Instructions for AI agents (Claude Code, Copilot, Cursor, etc.) working on this 
 
 ## What NOT to Do
 
-- Do not add ORMs (GORM, Prisma, etc.) — this project uses sqlc.
+- Do not add ORMs (GORM, Prisma, etc.) — this project uses sqlc for compile-time SQL generation (ADR-2).
 - Do not add Electron or Overwolf — this project uses Tauri.
-- Do not add REST endpoints — this project uses Connect RPC (gRPC).
+- Do not add REST endpoints — this project uses Connect RPC with Protobuf contracts (ADR-1).
+- Do not use raw gRPC — Connect RPC is used because Tauri's webview (browser) cannot speak HTTP/2 binary.
+- Do not route API calls through Tauri/Rust — React calls Go backend directly via HTTP (ADR-3).
 - Do not add Redux, MobX, or Recoil — this project uses Zustand + TanStack Query.
 - Do not read game memory or screen pixels — Vanguard anti-cheat risk.
 - Do not auto-detect lobbies via LCU API — users input Riot ID manually.
@@ -74,6 +77,7 @@ Instructions for AI agents (Claude Code, Copilot, Cursor, etc.) working on this 
 
 - Full spec: `docs/SPEC.md` (Portuguese)
 - Data source mapping: `docs/DATA_SOURCES.md` (CommunityDragon, Riot API, Scrapers)
+- Architecture decisions: `docs/ARCHITECTURE_DECISIONS.md` (ADR-1 to ADR-4)
 - Architecture and commands: `CLAUDE.md`
 - Protobuf contracts: `proto/tft/v1/patch.proto`, `proto/tft/v1/player.proto`
 - 4 development phases tracked via GitHub milestones (#1-#30)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,17 +11,26 @@ TFT Oracle is an ultra-lightweight desktop app (~50MB RAM) that acts as an AI-po
 ## Architecture
 
 ```
-┌──────────────────┐     gRPC/Connect     ┌──────────────────┐
-│   Tauri v2 App   │◄───────────────────►│   Go Backend     │
-│   React + Vite   │                      │   (Goroutines)   │
-│   TailwindCSS    │                      │                  │
-└──────────────────┘                      ├──────────────────┤
-                                          │  PostgreSQL      │
-                                          │  Redis (Phase 2) │
-                                          │  OpenAI API      │
-                                          │  Riot API        │
-                                          └──────────────────┘
+┌─────────────────────────────────┐
+│          Tauri v2 (Rust)        │  ← Window shell only, minimal logic
+│  ┌───────────────────────────┐  │
+│  │    React + Vite (WebView) │  │     HTTP + JSON (Connect RPC)
+│  │    TanStack Query hooks   │──────────────────────────►  Go Backend :8080
+│  │    Zustand (client state) │  │     (NOT raw gRPC — browser compatible)
+│  └───────────────────────────┘  │
+└─────────────────────────────────┘
+                                        ┌──────────────────┐
+                                        │  Go Backend      │
+                                        │  Connect RPC     │
+                                        ├──────────────────┤
+                                        │  PostgreSQL      │
+                                        │  Redis (Phase 2) │
+                                        │  OpenAI API      │
+                                        │  Riot API        │
+                                        └──────────────────┘
 ```
+
+**Communication flow:** React (inside Tauri's webview) calls Go backend directly via HTTP+JSON using Connect RPC. Tauri is just the desktop window — it does NOT proxy or relay API calls. Connect RPC is used instead of raw gRPC because browsers/webviews cannot speak gRPC's HTTP/2 binary protocol.
 
 ### Stack
 
@@ -32,7 +41,8 @@ TFT Oracle is an ultra-lightweight desktop app (~50MB RAM) that acts as an AI-po
 | State | TanStack Query + Zustand | Cache + client state |
 | DnD | @dnd-kit | Phase 3 board builder |
 | Backend | Go + Connect RPC (Buf) | Protobuf contracts → auto-generated React hooks |
-| DB access | sqlc + pgx | Compiled SQL, no ORM |
+| Communication | Connect RPC (HTTP+JSON) | NOT raw gRPC — browser/webview compatible |
+| DB access | sqlc + pgx | Compiled SQL, no ORM (see ADR below) |
 | Database | PostgreSQL v16+ | Relational storage |
 | Cache | Redis | Riot API rate limits (Phase 2+) |
 | AI | OpenAI GPT-4o-mini | Structured Outputs (JSON Schema) |
@@ -134,6 +144,24 @@ sqlc generate                               # Generate Go from SQL queries
 - Run `sqlc generate` to produce type-safe Go code
 - Never write raw SQL strings in Go code
 
+## Architecture Decision Records (ADRs)
+
+### ADR-1: Connect RPC instead of raw gRPC
+
+Tauri's webview is a browser — browsers cannot speak raw gRPC (HTTP/2 binary protocol). Connect RPC speaks HTTP/1.1 + JSON natively, so React calls the Go backend directly with no proxy. Connect RPC is fully compatible with gRPC clients and uses the same `.proto` contracts.
+
+### ADR-2: sqlc instead of ORM (GORM)
+
+GORM is Go's most popular ORM, but we use sqlc because:
+- **Performance**: sqlc generates plain Go functions at build time — no reflection, no model caching, no hidden queries. Critical for the ~50MB RAM target.
+- **Transparency**: you write the exact SQL that runs. No N+1 surprises, no "what query did the ORM generate?"
+- **Type safety**: sqlc catches errors at compile time, not runtime.
+- **Simplicity**: our queries are straightforward (get champions, store matches) — an ORM adds complexity with zero benefit here.
+
+### ADR-3: Tauri as window shell only
+
+Tauri (Rust) only manages the desktop window and process lifecycle. All business logic lives in the Go backend. React talks to Go directly — Tauri does NOT proxy or relay API calls. This keeps the Rust layer minimal and avoids duplicating logic.
+
 ## Key Constraints
 
 - **Performance**: Must stay under ~50MB RAM with zero FPS impact during gameplay
@@ -164,6 +192,7 @@ The `apiName` field is the universal join key across all data sources:
 
 - `docs/SPEC.md` — Full technical specification (Portuguese)
 - `docs/DATA_SOURCES.md` — Complete external data source mapping (CommunityDragon, Riot API, Scrapers)
+- `docs/ARCHITECTURE_DECISIONS.md` — ADRs: Connect RPC vs gRPC, sqlc vs ORM, Tauri role, Protobuf contracts
 - `proto/tft/v1/patch.proto` — PatchService contract (champions, items, traits)
 - `proto/tft/v1/player.proto` — PlayerService contract (profile, ranked, matches)
 - `buf.yaml` / `buf.gen.yaml` — Buf configuration for code generation

--- a/docs/ARCHITECTURE_DECISIONS.md
+++ b/docs/ARCHITECTURE_DECISIONS.md
@@ -1,0 +1,192 @@
+# Decisões de Arquitetura (ADRs) — TFT Oracle
+
+Registro das decisões técnicas fundamentais do projeto e suas justificativas.
+
+---
+
+## ADR-1: Connect RPC em vez de gRPC puro
+
+**Status:** Aceito
+**Data:** 2026-03-13
+
+### Contexto
+
+O TFT Oracle usa Tauri v2 como shell desktop. O Tauri renderiza a interface React dentro de uma **webview** (navegador). Precisamos que o React se comunique com o backend Go.
+
+### Problema
+
+O gRPC puro usa **HTTP/2 com protocolo binário** — navegadores não conseguem falar este protocolo nativamente. A solução tradicional é adicionar um proxy `grpc-web`, o que adiciona:
+- Mais um processo para gerenciar
+- Mais latência (hop extra)
+- Mais complexidade de deploy
+
+### Decisão
+
+Usar **Connect RPC** (feito pelo time do Buf) em vez de gRPC puro.
+
+### Como funciona
+
+```
+┌─────────────────────────────────┐
+│          Tauri v2 (Rust)        │  ← Só janela, sem lógica
+│  ┌───────────────────────────┐  │
+│  │    React (WebView)        │  │     HTTP/1.1 + JSON
+│  │    useQuery(getPatchData) │──────────────────────►  Go Backend :8080
+│  └───────────────────────────┘  │     Connect RPC
+└─────────────────────────────────┘
+```
+
+- React faz uma **requisição HTTP normal** com JSON no body
+- Go backend recebe via handler Connect RPC
+- Sem proxy, sem HTTP/2 obrigatório
+
+### Comparação
+
+| | gRPC puro | Connect RPC |
+|---|---|---|
+| Protocolo | HTTP/2, binário | HTTP/1.1 ou HTTP/2, JSON ou binário |
+| Browser/WebView | **Não** — precisa de proxy grpc-web | **Sim** — HTTP nativo |
+| Usa `.proto`? | Sim | Sim (mesmos contratos) |
+| Compatível com gRPC? | — | Sim, fala ambos protocolos |
+| Geração de código | protoc + plugins | `buf generate` (tudo integrado) |
+
+### Consequências
+
+- React chama Go diretamente — zero proxies
+- Mesmos `.proto` files geram Go + TypeScript
+- Auto-generated React hooks via `@connectrpc/connect-query`
+- Se no futuro precisarmos de um cliente gRPC nativo (ex: mobile), Connect RPC é compatível
+
+---
+
+## ADR-2: sqlc em vez de ORM (GORM)
+
+**Status:** Aceito
+**Data:** 2026-03-13
+
+### Contexto
+
+Precisamos de acesso ao PostgreSQL no backend Go. As duas opções principais são:
+- **GORM** — o ORM mais popular de Go (equivalente ao SQLAlchemy/Hibernate)
+- **sqlc** — compilador que transforma SQL puro em funções Go tipadas
+
+### Problema
+
+O TFT Oracle tem um target de **~50MB RAM** e precisa rodar sem impacto nos FPS do jogador. As queries são simples (buscar campeões, salvar partidas), não precisam de um ORM complexo.
+
+### Decisão
+
+Usar **sqlc + pgx** em vez de GORM.
+
+### Comparação
+
+| | GORM (ORM) | sqlc (SQL → Go) |
+|---|---|---|
+| Você escreve | Código Go que gera SQL | SQL puro que gera código Go |
+| Performance | Queries ocultas, reflection, N+1 | SQL exato, zero overhead |
+| Type safety | Erros em runtime | Erros em compile-time |
+| RAM | Reflection, caching de models | Zero — só funções geradas |
+| Debugging | "Que SQL o GORM gerou?" | Você escreveu o SQL |
+
+### Como funciona
+
+```sql
+-- backend/sqlc/queries/champions.sql
+-- name: GetChampionsBySet :many
+SELECT * FROM champions WHERE set_number = $1 ORDER BY cost;
+```
+
+```bash
+sqlc generate
+```
+
+```go
+// Gerado automaticamente — sem magia, sem reflection:
+func (q *Queries) GetChampionsBySet(ctx context.Context, setNumber int32) ([]Champion, error)
+```
+
+### Consequências
+
+- SQL é explícito — sem surpresas de N+1 ou queries ocultas
+- Erros de tipo são pegos em compile-time
+- Zero overhead de runtime — ideal para o target de ~50MB RAM
+- Precisa escrever SQL manualmente (trade-off aceito — queries são simples)
+
+---
+
+## ADR-3: Tauri como shell mínimo
+
+**Status:** Aceito
+**Data:** 2026-03-13
+
+### Contexto
+
+O Tauri v2 usa Rust para criar a janela desktop e embedda uma webview para a interface React.
+
+### Problema
+
+Existe a tentação de colocar lógica no Rust (Tauri commands, IPC complexo) para intermediar a comunicação React ↔ Go. Isso duplicaria lógica e adicionaria complexidade.
+
+### Decisão
+
+Tauri é **apenas o shell da janela**. Toda lógica de negócio fica no Go backend. React chama Go diretamente via HTTP.
+
+### Fluxo
+
+```
+❌ Errado:  React ──IPC──► Tauri (Rust) ──HTTP──► Go Backend
+✅ Correto: React ──HTTP──► Go Backend    |    Tauri = só janela
+```
+
+### Responsabilidades do Tauri (Rust)
+
+- Abrir e gerenciar a janela desktop
+- Configurar a webview (CSP, permissões)
+- Lifecycle do processo (iniciar/parar backend Go)
+- **Nada mais** — sem lógica de negócio, sem proxy de API
+
+### Consequências
+
+- Rust layer fica mínimo e fácil de manter
+- Sem duplicação de lógica entre Rust e Go
+- React pode ser desenvolvido/testado independentemente no browser
+- Build mais rápido (menos código Rust para compilar)
+
+---
+
+## ADR-4: Protobuf como contrato único
+
+**Status:** Aceito
+**Data:** 2026-03-13
+
+### Decisão
+
+Os arquivos `.proto` são a **única fonte de verdade** para a API. Não existem DTOs paralelos, types manuais, ou schemas duplicados.
+
+### Fluxo de geração
+
+```
+proto/tft/v1/patch.proto
+        │
+        ▼  buf generate
+        │
+        ├──► backend/gen/    → Go structs + Connect handlers
+        └──► frontend/src/gen/ → TypeScript types + React hooks
+```
+
+### Regras
+
+- Nunca editar código em `backend/gen/` ou `frontend/src/gen/` — é gerado
+- Sempre rodar `buf lint` antes de commitar mudanças em `.proto`
+- Sempre rodar `buf generate` depois de alterar protos
+- O campo `apiName` é a chave universal de junção entre CommunityDragon e Riot API
+
+---
+
+## Referências
+
+- [Connect RPC Documentation](https://connectrpc.com/)
+- [Buf Documentation](https://buf.build/docs/)
+- [sqlc Documentation](https://docs.sqlc.dev/)
+- [GORM Documentation](https://gorm.io/) (referência — não usado no projeto)
+- [Tauri v2 Architecture](https://v2.tauri.app/concept/)


### PR DESCRIPTION
## Summary

- Added `docs/ARCHITECTURE_DECISIONS.md` with 4 ADRs documenting core technical decisions
- Updated `CLAUDE.md` with corrected architecture diagram, ADR section, and stack clarifications
- Updated `AGENTS.md` with Connect RPC, sqlc, and Tauri role guidance

## ADRs

- **ADR-1**: Connect RPC instead of raw gRPC — browser/webview can't speak HTTP/2 binary
- **ADR-2**: sqlc instead of ORM (GORM) — zero runtime overhead, ~50MB RAM target
- **ADR-3**: Tauri as minimal window shell — React calls Go directly, no proxy
- **ADR-4**: Protobuf as single source of truth — `buf generate` for Go + TypeScript

## Test plan

- [x] Documentation review — ADRs are accurate and consistent with SPEC.md
- [x] CLAUDE.md and AGENTS.md updated with correct references

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)