### PR TITLE
fix: filter non-playable units from champions list

### DIFF
--- a/backend/internal/cdragon/parser.go
+++ b/backend/internal/cdragon/parser.go
@@ -116,10 +116,14 @@ func Parse(data *CDragonData) *ParsedSet {
 		})
 	}
 
-	// Parse champions
+	// Parse champions (filter non-playable units: monsters, anvils, summons)
 	champions := make([]ParsedChampion, 0, len(setData.Champions))
 	for _, c := range setData.Champions {
 		traitAPINames := resolveTraitNames(c.Traits, traitDisplayToAPI)
+
+		if !isPlayableChampion(c.Cost, traitAPINames) {
+			continue
+		}
 
 		ability := ParsedAbility{
 			Name:    c.Ability.Name,
@@ -186,6 +190,16 @@ func resolveTraitNames(displayNames []string, displayToAPI map[string]string) []
 		}
 	}
 	return result
+}
+
+// isPlayableChampion returns true if a champion is a real playable unit.
+// Non-playable entities leak through CommunityDragon data as:
+//   - PvE monsters/dummies (cost 1, but 0 traits)
+//   - Item anvils (cost 8)
+//   - Summons/minions (cost 11)
+func isPlayableChampion(cost int, resolvedTraits []string) bool {
+	// Real champions cost 1-5 and always have at least one trait.
+	return cost >= 1 && cost <= 5 && len(resolvedTraits) > 0
 }
 
 // filterItems filters the global items list for items belonging to the current set.

--- a/backend/internal/cdragon/parser_test.go
+++ b/backend/internal/cdragon/parser_test.go
@@ -126,6 +126,87 @@ func TestResolveTraitNames(t *testing.T) {
 	}
 }
 
+func TestIsPlayableChampion(t *testing.T) {
+	tests := []struct {
+		name     string
+		cost     int
+		traits   []string
+		expected bool
+	}{
+		{"normal 1-cost with traits", 1, []string{"Set16_Warrior"}, true},
+		{"normal 5-cost with traits", 5, []string{"Set16_Sorcerer", "Set16_Guardian"}, true},
+		{"anvil cost 8", 8, []string{}, false},
+		{"summon cost 11", 11, []string{}, false},
+		{"monster cost 1 no traits", 1, []string{}, false},
+		{"dummy cost 1 no traits", 1, []string{}, false},
+		{"cost 0 excluded", 0, []string{"Set16_Warrior"}, false},
+		{"cost 6 excluded", 6, []string{"Set16_Warrior"}, false},
+		{"negative cost excluded", -1, []string{"Set16_Warrior"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPlayableChampion(tt.cost, tt.traits)
+			if got != tt.expected {
+				t.Errorf("isPlayableChampion(%d, %v) = %v, want %v", tt.cost, tt.traits, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseFiltersNonPlayableUnits(t *testing.T) {
+	data := &CDragonData{
+		SetData: []CDragonSetData{
+			{
+				Number:  16,
+				Name:    "Set 16",
+				Mutator: "TFTSet16",
+				Traits: []CDragonTrait{
+					{APIName: "Set16_Warrior", Name: "Warrior"},
+					{APIName: "Set16_Sorcerer", Name: "Sorcerer"},
+				},
+				Champions: []CDragonChampion{
+					// Playable champions
+					{APIName: "TFT16_Garen", Name: "Garen", Cost: 1, Traits: []string{"Warrior"}},
+					{APIName: "TFT16_Lux", Name: "Lux", Cost: 5, Traits: []string{"Sorcerer"}},
+					// PvE monster (cost 1, no traits)
+					{APIName: "TFT_ElderDragon", Name: "Elder Dragon", Cost: 1, Traits: []string{}},
+					// PvE monster from old set (cost 1, traits won't resolve)
+					{APIName: "TFT9_SLIME_Crab", Name: "Rift Scuttler", Cost: 1, Traits: []string{"OldSetTrait"}},
+					// Training dummy (cost 1, no traits)
+					{APIName: "TFT_TrainingDummy", Name: "Training Dummy", Cost: 1, Traits: []string{}},
+					// Item anvil (cost 8)
+					{APIName: "TFT_ArmoryKeyOrnn", Name: "Artifact Item Anvil", Cost: 8, Traits: []string{}},
+					// Summon (cost 11)
+					{APIName: "TFT16_AnnieTibbers", Name: "Tibbers", Cost: 11, Traits: []string{}},
+					// Trait mechanic summon (cost 1, no traits)
+					{APIName: "TFT16_PiltoverInvention", Name: "Piltover Invention", Cost: 1, Traits: []string{}},
+				},
+			},
+		},
+	}
+
+	parsed := Parse(data)
+	if parsed == nil {
+		t.Fatal("expected parsed set, got nil")
+	}
+
+	if len(parsed.Champions) != 2 {
+		names := make([]string, len(parsed.Champions))
+		for i, c := range parsed.Champions {
+			names[i] = c.APIName
+		}
+		t.Errorf("expected 2 playable champions, got %d: %v", len(parsed.Champions), names)
+	}
+
+	// Verify only real champions remain
+	for _, c := range parsed.Champions {
+		if c.APIName != "TFT16_Garen" && c.APIName != "TFT16_Lux" {
+			t.Errorf("unexpected champion in results: %s", c.APIName)
+		}
+	}
+}
+
 func TestHasSetNumber(t *testing.T) {
 	tests := []struct {
 		apiName  string


### PR DESCRIPTION
## Summary
- Add `isPlayableChampion` filter in CommunityDragon parser that requires cost 1-5 and at least 1 resolved trait
- Eliminates 16 non-playable entities (PvE monsters, item anvils, summons, training dummies) from `GetPatchData` results
- Data-driven approach — no hardcoded deny lists needed

## How it works
| Rule | Eliminates |
|------|-----------|
| `cost >= 1 && cost <= 5` | Anvils (cost 8), summons (cost 11) |
| `len(resolvedTraits) > 0` | PvE monsters, dummies, mechanic summons (0 traits), old-set entities (traits don't resolve) |

## Test plan
- [x] `TestIsPlayableChampion` — unit tests for all edge cases (valid costs, anvils, summons, monsters, boundary costs)
- [x] `TestParseFiltersNonPlayableUnits` — integration test with mixed playable/non-playable champions through full `Parse` pipeline
- [x] All existing tests pass (`go test ./...`)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)