### PR TITLE
fix: filter non-item entries from items list

### DIFF
--- a/backend/internal/cdragon/parser.go
+++ b/backend/internal/cdragon/parser.go
@@ -202,40 +202,18 @@ func isPlayableChampion(cost int, resolvedTraits []string) bool {
 	return cost >= 1 && cost <= 5 && len(resolvedTraits) > 0
 }
 
-// filterItems filters the global items list for items belonging to the current set.
+// filterItems filters the global items list, keeping only real equipable items
+// for the current set. Non-item entries (augments, assists, consumables, events,
+// tutorials, champion mechanics) are excluded via an allow-list approach.
 func filterItems(allItems []CDragonItem, setMutator string, setNumber int) []ParsedItem {
 	items := make([]ParsedItem, 0)
-	setTag := strings.ToLower(setMutator)
+	setPrefix := strings.ToLower("tft" + itoa(setNumber) + "_item_")
 
 	for _, item := range allItems {
-		// Include base items (no set-specific tag needed) and set-specific items.
-		// Items are included if they have no "Set" prefix in apiName OR if they match current set.
 		apiLower := strings.ToLower(item.APIName)
 
-		// Skip items from other sets
-		if strings.HasPrefix(apiLower, "tft") {
-			// Check if it belongs to a different set number
-			belongsToCurrentSet := false
-
-			// Base TFT items (e.g., "TFT_Item_BFSword") belong to all sets
-			if !hasSetNumber(apiLower) {
-				belongsToCurrentSet = true
-			}
-
-			// Set-specific items contain the set identifier
-			if setTag != "" && strings.Contains(apiLower, strings.ToLower(setTag)) {
-				belongsToCurrentSet = true
-			}
-
-			// Also check for set number in the apiName (e.g., "TFT13_...")
-			setPrefix := strings.ToLower("TFT" + itoa(setNumber))
-			if strings.HasPrefix(apiLower, setPrefix+"_") {
-				belongsToCurrentSet = true
-			}
-
-			if !belongsToCurrentSet {
-				continue
-			}
+		if !isRealItem(apiLower, setPrefix) {
+			continue
 		}
 
 		items = append(items, ParsedItem{
@@ -253,6 +231,18 @@ func filterItems(allItems []CDragonItem, setMutator string, setNumber int) []Par
 	}
 
 	return items
+}
+
+// isRealItem returns true if the apiName represents a real equipable item.
+// Real items follow two patterns:
+//   - Base items: "tft_item_*" (components + universally crafted items)
+//   - Set items:  "tft{N}_item_*" (set-specific items, e.g. "tft16_item_*")
+//
+// Everything else (augments, assists, consumables, events, tutorials,
+// champion mechanics) is filtered out.
+func isRealItem(apiNameLower string, setItemPrefix string) bool {
+	return strings.HasPrefix(apiNameLower, "tft_item_") ||
+		strings.HasPrefix(apiNameLower, setItemPrefix)
 }
 
 // hasSetNumber checks if an item apiName contains a set number suffix (e.g., TFT9_, TFT13_).

--- a/backend/internal/cdragon/parser_test.go
+++ b/backend/internal/cdragon/parser_test.go
@@ -207,6 +207,86 @@ func TestParseFiltersNonPlayableUnits(t *testing.T) {
 	}
 }
 
+func TestIsRealItem(t *testing.T) {
+	setItemPrefix := "tft16_item_"
+
+	tests := []struct {
+		name     string
+		apiName  string
+		expected bool
+	}{
+		// Real items — should pass
+		{"base component", "tft_item_bfsword", true},
+		{"base crafted item", "tft_item_guinsoosrageblade", true},
+		{"set-specific item", "tft16_item_specialweapon", true},
+
+		// Non-items — should be filtered
+		{"generic augment", "tft_augment_cyberbuff", false},
+		{"set augment", "tft16_augment_somebuff", false},
+		{"teamup augment", "tft16_teamupaugment_duo", false},
+		{"assist gold", "tft_assist_gold_1", false},
+		{"assist rerolls", "tft_assist_rerolls_11", false},
+		{"generic consumable", "tft_consumable_something", false},
+		{"set consumable", "tft16_consumable_something", false},
+		{"explorer reward", "tft16_explorer_reward", false},
+		{"champion mechanic", "tft16_championitem_special", false},
+		{"xerath mechanic", "tft16_xerathzap_damage", false},
+		{"event item", "tftevent_5yr_item_something", false},
+		{"tutorial augment", "tfttutorial_augment_something", false},
+		{"other set item", "tft9_item_oldsword", false},
+		{"armory key", "tft_armorykey_component", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRealItem(tt.apiName, setItemPrefix)
+			if got != tt.expected {
+				t.Errorf("isRealItem(%q, %q) = %v, want %v", tt.apiName, setItemPrefix, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFilterItemsIntegration(t *testing.T) {
+	allItems := []CDragonItem{
+		// Real items
+		{APIName: "TFT_Item_BFSword", Name: "B.F. Sword"},
+		{APIName: "TFT_Item_GuinsoosRageblade", Name: "Guinsoo's Rageblade"},
+		{APIName: "TFT16_Item_SpecialWeapon", Name: "Special Weapon"},
+		// Non-items
+		{APIName: "TFT_Augment_CyberBuff", Name: "Cyber Buff"},
+		{APIName: "TFT16_Augment_SomeBuff", Name: "Some Buff"},
+		{APIName: "TFT_Assist_Gold_1", Name: "1 Gold"},
+		{APIName: "TFT_Consumable_Remover", Name: "Remover"},
+		{APIName: "TFT16_Explorer_Reward", Name: "Explorer Reward"},
+		{APIName: "TFT16_XerathZap_Damage", Name: "Xerath Zap"},
+		{APIName: "TFTEvent_5YR_Item_Sword", Name: "Event Sword"},
+		{APIName: "TFTTutorial_Augment_Starter", Name: "Tutorial Augment"},
+		{APIName: "TFT9_Item_OldSword", Name: "Old Sword"},
+	}
+
+	items := filterItems(allItems, "TFTSet16", 16)
+
+	if len(items) != 3 {
+		names := make([]string, len(items))
+		for i, item := range items {
+			names[i] = item.APIName
+		}
+		t.Errorf("expected 3 real items, got %d: %v", len(items), names)
+	}
+
+	expected := map[string]bool{
+		"TFT_Item_BFSword":         true,
+		"TFT_Item_GuinsoosRageblade": true,
+		"TFT16_Item_SpecialWeapon": true,
+	}
+	for _, item := range items {
+		if !expected[item.APIName] {
+			t.Errorf("unexpected item in results: %s", item.APIName)
+		}
+	}
+}
+
 func TestHasSetNumber(t *testing.T) {
 	tests := []struct {
 		apiName  string


### PR DESCRIPTION
## Summary
- Replace set-only item filtering with an **allow-list** approach using `isRealItem`
- Only keeps entries matching `TFT_Item_*` (base items) or `TFT{N}_Item_*` (current set items)
- Drops ~839 non-item entries: augments, assists, consumables, events, tutorials, champion mechanics, explorer rewards, etc.

## How it works
| Pattern | Keeps |
|---------|-------|
| `TFT_Item_*` | Base components + universally crafted items (~185) |
| `TFT16_Item_*` | Set 16 specific items (~83) |
| Everything else | Filtered out |

## Test plan
- [x] `TestIsRealItem` — unit tests covering all item categories (real items, augments, assists, consumables, events, tutorials, mechanics, old set items)
- [x] `TestFilterItemsIntegration` — integration test with mixed real/non-item entries through `filterItems`
- [x] All existing tests pass (`go test ./...`)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)