### PR TITLE
feat: Phase 2 — Riot API integration, player dashboard & analytics

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -18,11 +18,13 @@ import (
 	"golang.org/x/net/http2/h2c"
 
 	"github.com/MeninoNias/tft-oracle/backend/gen/tft/v1/tftv1connect"
+	"github.com/MeninoNias/tft-oracle/backend/internal/cache"
 	"github.com/MeninoNias/tft-oracle/backend/internal/cdragon"
 	"github.com/MeninoNias/tft-oracle/backend/internal/config"
 	"github.com/MeninoNias/tft-oracle/backend/internal/database"
 	"github.com/MeninoNias/tft-oracle/backend/internal/patch"
 	"github.com/MeninoNias/tft-oracle/backend/internal/player"
+	"github.com/MeninoNias/tft-oracle/backend/internal/riot"
 )
 
 func main() {
@@ -71,6 +73,31 @@ func main() {
 		}
 	}
 
+	// Redis (optional)
+	var cacheClient *cache.Client
+	if cfg.RedisURL != "" {
+		var err error
+		cacheClient, err = cache.NewClient(cfg.RedisURL)
+		if err != nil {
+			log.Printf("warning: redis connection failed: %v (continuing without cache)", err)
+		} else if cacheClient != nil {
+			log.Println("redis: connected")
+			defer cacheClient.Close()
+		}
+	}
+
+	// Riot API client
+	riotClient := riot.NewClient(cfg.RiotAPIKey)
+	if riotClient.Available() {
+		if err := riotClient.HealthCheck(ctx); err != nil {
+			log.Printf("riot api: WARNING — key validation failed: %v", err)
+		} else {
+			log.Println("riot api: key valid")
+		}
+	} else {
+		log.Println("riot api: not configured (player features disabled)")
+	}
+
 	// Set up Connect RPC handlers
 	mux := http.NewServeMux()
 
@@ -83,7 +110,7 @@ func main() {
 	mux.Handle(patchPath, patchHandler)
 
 	playerPath, playerHandler := tftv1connect.NewPlayerServiceHandler(
-		player.NewService(),
+		player.NewService(pool, riotClient, cacheClient),
 		interceptors,
 	)
 	mux.Handle(playerPath, playerHandler)
@@ -123,10 +150,10 @@ func main() {
 		WriteTimeout: 30 * time.Second,
 	}
 
-	// Graceful shutdown
+	// Graceful shutdown (os.Interrupt works reliably on Windows)
 	go func() {
 		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		signal.Notify(sigCh, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 		<-sigCh
 		log.Println("shutting down...")
 		cancel()

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -13,10 +13,15 @@ require (
 )
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/lib/pq v1.10.9 // indirect
+	github.com/redis/go-redis/v9 v9.18.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -4,6 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
@@ -11,6 +13,8 @@ github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmC
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dhui/dktest v0.4.6 h1:+DPKyScKSEp3VLtbMDHcUq6V5Lm5zfZZVb0Sk7Ahom4=
 github.com/dhui/dktest v0.4.6/go.mod h1:JHTSYDtKkvFNFHJKqCzVzqXecyv+tKt8EzceOmQOgbU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
@@ -60,6 +64,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
+github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -77,6 +83,8 @@ go.opentelemetry.io/otel/metric v1.37.0 h1:mvwbQS5m0tbmqML4NqK+e3aDiO02vsf/Wgbsd
 go.opentelemetry.io/otel/metric v1.37.0/go.mod h1:04wGrZurHYKOc+RKeye86GwKiTb9FKm1WHtO+4EVr2E=
 go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mxVK7z4=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
 golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
@@ -85,6 +93,8 @@ golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
 golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
+golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
+golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/backend/internal/cache/redis.go
+++ b/backend/internal/cache/redis.go
@@ -1,0 +1,154 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var ErrCacheMiss = errors.New("cache miss")
+
+type Client struct {
+	rdb *redis.Client
+}
+
+// NewClient creates a Redis cache client. Returns nil, nil if redisURL is empty.
+func NewClient(redisURL string) (*Client, error) {
+	if redisURL == "" {
+		return nil, nil
+	}
+
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse redis url: %w", err)
+	}
+
+	rdb := redis.NewClient(opts)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := rdb.Ping(ctx).Err(); err != nil {
+		return nil, fmt.Errorf("redis ping: %w", err)
+	}
+
+	return &Client{rdb: rdb}, nil
+}
+
+// Close closes the Redis connection.
+func (c *Client) Close() error {
+	if c == nil {
+		return nil
+	}
+	return c.rdb.Close()
+}
+
+// --- PUUID cache (24h TTL) ---
+
+func (c *Client) GetPUUID(ctx context.Context, gameName, tagLine string) (string, error) {
+	if c == nil {
+		return "", ErrCacheMiss
+	}
+	val, err := c.rdb.Get(ctx, puuidKey(gameName, tagLine)).Result()
+	if err != nil {
+		return "", ErrCacheMiss
+	}
+	return val, nil
+}
+
+func (c *Client) SetPUUID(ctx context.Context, gameName, tagLine, puuid string) {
+	if c == nil {
+		return
+	}
+	_ = c.rdb.Set(ctx, puuidKey(gameName, tagLine), puuid, 24*time.Hour).Err()
+}
+
+// --- Player profile cache (10min TTL) ---
+
+func (c *Client) GetPlayerProfile(ctx context.Context, puuid string) ([]byte, error) {
+	if c == nil {
+		return nil, ErrCacheMiss
+	}
+	val, err := c.rdb.Get(ctx, profileKey(puuid)).Bytes()
+	if err != nil {
+		return nil, ErrCacheMiss
+	}
+	return val, nil
+}
+
+func (c *Client) SetPlayerProfile(ctx context.Context, puuid string, data []byte) {
+	if c == nil {
+		return
+	}
+	_ = c.rdb.Set(ctx, profileKey(puuid), data, 10*time.Minute).Err()
+}
+
+// --- Match IDs cache (5min TTL) ---
+
+func (c *Client) GetMatchIDs(ctx context.Context, puuid string) ([]string, error) {
+	if c == nil {
+		return nil, ErrCacheMiss
+	}
+	val, err := c.rdb.LRange(ctx, matchIDsKey(puuid), 0, -1).Result()
+	if err != nil || len(val) == 0 {
+		return nil, ErrCacheMiss
+	}
+	return val, nil
+}
+
+func (c *Client) SetMatchIDs(ctx context.Context, puuid string, ids []string) {
+	if c == nil || len(ids) == 0 {
+		return
+	}
+	key := matchIDsKey(puuid)
+	pipe := c.rdb.Pipeline()
+	pipe.Del(ctx, key)
+	vals := make([]interface{}, len(ids))
+	for i, id := range ids {
+		vals[i] = id
+	}
+	pipe.RPush(ctx, key, vals...)
+	pipe.Expire(ctx, key, 5*time.Minute)
+	_, _ = pipe.Exec(ctx)
+}
+
+// --- Match detail cache (permanent — matches are immutable) ---
+
+func (c *Client) GetMatchDetail(ctx context.Context, matchID string) ([]byte, error) {
+	if c == nil {
+		return nil, ErrCacheMiss
+	}
+	val, err := c.rdb.Get(ctx, matchKey(matchID)).Bytes()
+	if err != nil {
+		return nil, ErrCacheMiss
+	}
+	return val, nil
+}
+
+func (c *Client) SetMatchDetail(ctx context.Context, matchID string, data []byte) {
+	if c == nil {
+		return
+	}
+	_ = c.rdb.Set(ctx, matchKey(matchID), data, 0).Err() // 0 = no expiration
+}
+
+// --- Key helpers ---
+
+func puuidKey(gameName, tagLine string) string {
+	return fmt.Sprintf("puuid:%s:%s", gameName, tagLine)
+}
+
+func profileKey(puuid string) string {
+	return fmt.Sprintf("profile:%s", puuid)
+}
+
+func matchIDsKey(puuid string) string {
+	return fmt.Sprintf("matches:%s", puuid)
+}
+
+func matchKey(matchID string) string {
+	return fmt.Sprintf("match:%s", matchID)
+}

--- a/backend/internal/cdragon/parser.go
+++ b/backend/internal/cdragon/parser.go
@@ -212,7 +212,7 @@ func filterItems(allItems []CDragonItem, setMutator string, setNumber int) []Par
 	for _, item := range allItems {
 		apiLower := strings.ToLower(item.APIName)
 
-		if !isRealItem(apiLower, setPrefix) {
+		if !isRealItem(apiLower, setPrefix, item.Name) {
 			continue
 		}
 
@@ -238,11 +238,64 @@ func filterItems(allItems []CDragonItem, setMutator string, setNumber int) []Par
 //   - Base items: "tft_item_*" (components + universally crafted items)
 //   - Set items:  "tft{N}_item_*" (set-specific items, e.g. "tft16_item_*")
 //
-// Everything else (augments, assists, consumables, events, tutorials,
-// champion mechanics) is filtered out.
-func isRealItem(apiNameLower string, setItemPrefix string) bool {
-	return strings.HasPrefix(apiNameLower, "tft_item_") ||
-		strings.HasPrefix(apiNameLower, setItemPrefix)
+// Within those prefixes, several sub-patterns are excluded:
+//   - Grant*: loot drop mechanics (GrantComponent, GrantOrbs, GrantCompletedItem, etc.)
+//   - Debug*: debug/test items
+//   - Free*:  free component duplicates (FreeBFSword, etc.)
+//   - *Copy*: internal duplicates (ThiefsGloves_AcademyCopy)
+//   - Blank/EmptyBag: placeholder items
+//   - Piltover_*/Bilgewater_*: region-specific champion mechanics (not equippable)
+//   - ChampionItem_*: champion-specific internal items
+//
+// Items with empty names or unresolved @variable@ templates are also excluded.
+func isRealItem(apiNameLower string, setItemPrefix string, name string) bool {
+	if !strings.HasPrefix(apiNameLower, "tft_item_") &&
+		!strings.HasPrefix(apiNameLower, setItemPrefix) {
+		return false
+	}
+
+	// Exclude items with empty, template, or unlocalized names.
+	// Unlocalized names look like "tft_item_name_*" or "game_item_displayname_*".
+	if name == "" || strings.Contains(name, "@") {
+		return false
+	}
+	nameLower := strings.ToLower(name)
+	if strings.HasPrefix(nameLower, "tft_item_") || strings.HasPrefix(nameLower, "game_item_") {
+		return false
+	}
+
+	// Deny-list: non-equippable sub-patterns within tft_item_ / tft{N}_item_
+	denyPrefixes := []string{
+		"tft_item_grant",
+		"tft_item_debug",
+		"tft_item_free",
+		"tft_item_blank",
+		"tft_item_emptybag",
+	}
+	for _, prefix := range denyPrefixes {
+		if strings.HasPrefix(apiNameLower, prefix) {
+			return false
+		}
+	}
+
+	// Deny sub-patterns within set items (e.g. tft16_item_piltover_, tft16_item_bilgewater_)
+	setDenyContains := []string{
+		"_piltover_",
+		"_bilgewater_",
+		"_championitem_",
+	}
+	for _, substr := range setDenyContains {
+		if strings.Contains(apiNameLower, substr) {
+			return false
+		}
+	}
+
+	// Deny internal copies
+	if strings.Contains(apiNameLower, "copy") {
+		return false
+	}
+
+	return true
 }
 
 // hasSetNumber checks if an item apiName contains a set number suffix (e.g., TFT9_, TFT13_).

--- a/backend/internal/cdragon/parser_test.go
+++ b/backend/internal/cdragon/parser_test.go
@@ -213,35 +213,47 @@ func TestIsRealItem(t *testing.T) {
 	tests := []struct {
 		name     string
 		apiName  string
+		itemName string
 		expected bool
 	}{
 		// Real items — should pass
-		{"base component", "tft_item_bfsword", true},
-		{"base crafted item", "tft_item_guinsoosrageblade", true},
-		{"set-specific item", "tft16_item_specialweapon", true},
+		{"base component", "tft_item_bfsword", "B.F. Sword", true},
+		{"base crafted item", "tft_item_guinsoosrageblade", "Guinsoo's Rageblade", true},
+		{"set-specific item", "tft16_item_specialweapon", "Special Weapon", true},
+		{"artifact item", "tft_item_artifact_blightingjewel", "Blighting Jewel", true},
+		{"set emblem", "tft16_item_sorcereremblemitem", "Arcanist Emblem", true},
 
 		// Non-items — should be filtered
-		{"generic augment", "tft_augment_cyberbuff", false},
-		{"set augment", "tft16_augment_somebuff", false},
-		{"teamup augment", "tft16_teamupaugment_duo", false},
-		{"assist gold", "tft_assist_gold_1", false},
-		{"assist rerolls", "tft_assist_rerolls_11", false},
-		{"generic consumable", "tft_consumable_something", false},
-		{"set consumable", "tft16_consumable_something", false},
-		{"explorer reward", "tft16_explorer_reward", false},
-		{"champion mechanic", "tft16_championitem_special", false},
-		{"xerath mechanic", "tft16_xerathzap_damage", false},
-		{"event item", "tftevent_5yr_item_something", false},
-		{"tutorial augment", "tfttutorial_augment_something", false},
-		{"other set item", "tft9_item_oldsword", false},
-		{"armory key", "tft_armorykey_component", false},
+		{"generic augment", "tft_augment_cyberbuff", "Cyber Buff", false},
+		{"set augment", "tft16_augment_somebuff", "Some Buff", false},
+		{"teamup augment", "tft16_teamupaugment_duo", "Duo Buff", false},
+		{"assist gold", "tft_assist_gold_1", "1 Gold", false},
+		{"grant component", "tft_item_grantcomponent1", "1 component", false},
+		{"grant orbs", "tft_item_grantorbs5", "@OrbsToGive@ loot orbs", false},
+		{"grant completed", "tft_item_grantcompleteditem2", "@ItemsToGive@ completed items", false},
+		{"grant anvil", "tft_item_grantcomponentanvil", "Component Anvil", false},
+		{"debug item", "tft_item_debugbase", "Debug Base", false},
+		{"debug damage", "tft_item_debugdamage", "Debug Damage", false},
+		{"free component", "tft_item_freebfsword", "B.F. Sword", false},
+		{"blank item", "tft_item_blank", "", false},
+		{"empty bag", "tft_item_emptybag", "", false},
+		{"copy item", "tft_item_thiefsgloves_academycopy", "Thief's Gloves", false},
+		{"piltover mechanic", "tft16_item_piltover_accelerationgate", "Acceleration Gate", false},
+		{"bilgewater mechanic", "tft16_item_bilgewater_deadmansdagger", "Dead Man's Dagger", false},
+		{"champion item", "tft16_championitem_special", "Special", false},
+		{"template name", "tft_item_something", "@ItemsToGive@ stuff", false},
+		{"empty name", "tft_item_something", "", false},
+		{"unlocalized tft name", "tft_item_cursedblade", "tft_item_name_CursedBlade", false},
+		{"unlocalized game name", "tft_item_mortalreminder", "game_item_displayname_3033", false},
+		{"other set item", "tft9_item_oldsword", "Old Sword", false},
+		{"armory key", "tft_armorykey_component", "Component", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isRealItem(tt.apiName, setItemPrefix)
+			got := isRealItem(tt.apiName, setItemPrefix, tt.itemName)
 			if got != tt.expected {
-				t.Errorf("isRealItem(%q, %q) = %v, want %v", tt.apiName, setItemPrefix, got, tt.expected)
+				t.Errorf("isRealItem(%q, %q, %q) = %v, want %v", tt.apiName, setItemPrefix, tt.itemName, got, tt.expected)
 			}
 		})
 	}

--- a/backend/internal/cdragon/sync.go
+++ b/backend/internal/cdragon/sync.go
@@ -101,7 +101,12 @@ func (s *Syncer) store(ctx context.Context, parsed *ParsedSet) error {
 		}
 	}
 
-	// 3. Upsert champions
+	// 3. Delete old champions for this set, then re-insert.
+	// This ensures stale entries (non-playable units from older syncs) are removed.
+	if err := qtx.DeleteChampionsBySet(ctx, setNumber); err != nil {
+		return fmt.Errorf("delete champions: %w", err)
+	}
+
 	for _, c := range parsed.Champions {
 		statsJSON, err := json.Marshal(map[string]interface{}{
 			"hp":              c.Stats.HP,
@@ -172,7 +177,11 @@ func (s *Syncer) store(ctx context.Context, parsed *ParsedSet) error {
 		}
 	}
 
-	// 5. Upsert items
+	// 5. Delete old items for this set, then re-insert (same as champions).
+	if err := qtx.DeleteItemsBySet(ctx, setNumber); err != nil {
+		return fmt.Errorf("delete items: %w", err)
+	}
+
 	for _, item := range parsed.Items {
 		effectsJSON, err := json.Marshal(item.Effects)
 		if err != nil {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -33,7 +33,7 @@ func Load() (*Config, error) {
 	}
 
 	if cfg.RiotAPIKey == "" {
-		return nil, fmt.Errorf("RIOT_API_KEY is required")
+		fmt.Println("WARNING: RIOT_API_KEY not set — player features will be unavailable")
 	}
 
 	return cfg, nil

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -11,6 +11,10 @@ type Config struct {
 	ServerHost  string
 	AppEnv      string
 	LogLevel    string
+
+	// Phase 2: Riot API & Redis
+	RiotAPIKey string
+	RedisURL   string
 }
 
 func Load() (*Config, error) {
@@ -20,10 +24,16 @@ func Load() (*Config, error) {
 		ServerHost:  getEnv("SERVER_HOST", "localhost"),
 		AppEnv:      getEnv("APP_ENV", "development"),
 		LogLevel:    getEnv("LOG_LEVEL", "debug"),
+		RiotAPIKey:  getEnv("RIOT_API_KEY", ""),
+		RedisURL:    getEnv("REDIS_URL", "redis://localhost:6379"),
 	}
 
 	if cfg.DatabaseURL == "" {
 		return nil, fmt.Errorf("DATABASE_URL is required")
+	}
+
+	if cfg.RiotAPIKey == "" {
+		return nil, fmt.Errorf("RIOT_API_KEY is required")
 	}
 
 	return cfg, nil

--- a/backend/internal/player/mapper.go
+++ b/backend/internal/player/mapper.go
@@ -1,0 +1,287 @@
+package player
+
+import (
+	"encoding/json"
+
+	tftv1 "github.com/MeninoNias/tft-oracle/backend/gen/tft/v1"
+	"github.com/MeninoNias/tft-oracle/backend/internal/riot"
+	"github.com/MeninoNias/tft-oracle/backend/sqlc/generated"
+)
+
+// --- Riot DTO → Proto ---
+
+func mapAccountToProto(dto *riot.AccountDTO) *tftv1.Account {
+	return &tftv1.Account{
+		Puuid:    dto.PUUID,
+		GameName: dto.GameName,
+		TagLine:  dto.TagLine,
+	}
+}
+
+func mapSummonerToProto(dto *riot.SummonerDTO) *tftv1.Summoner {
+	return &tftv1.Summoner{
+		Id:            dto.ID,
+		Puuid:         dto.PUUID,
+		ProfileIconId: dto.ProfileIconID,
+		SummonerLevel: dto.SummonerLevel,
+		RevisionDate:  dto.RevisionDate,
+	}
+}
+
+func mapLeagueEntriesToProto(entries []riot.LeagueEntryDTO) []*tftv1.RankedEntry {
+	result := make([]*tftv1.RankedEntry, 0, len(entries))
+	for _, e := range entries {
+		entry := &tftv1.RankedEntry{
+			QueueType:    e.QueueType,
+			Tier:         e.Tier,
+			Rank:         e.Rank,
+			LeaguePoints: e.LeaguePoints,
+			Wins:         e.Wins,
+			Losses:       e.Losses,
+			HotStreak:    e.HotStreak,
+			Veteran:      e.Veteran,
+			FreshBlood:   e.FreshBlood,
+			Inactive:     e.Inactive,
+		}
+		if e.MiniSeries != nil {
+			entry.MiniSeries = &tftv1.MiniSeries{
+				Progress: e.MiniSeries.Progress,
+				Wins:     e.MiniSeries.Wins,
+				Losses:   e.MiniSeries.Losses,
+				Target:   e.MiniSeries.Target,
+			}
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+func mapMatchToProto(dto *riot.MatchDTO) *tftv1.Match {
+	participants := make([]*tftv1.Participant, 0, len(dto.Info.Participants))
+	for _, p := range dto.Info.Participants {
+		participants = append(participants, mapParticipantToProto(&p))
+	}
+
+	return &tftv1.Match{
+		Metadata: &tftv1.MatchMetadata{
+			DataVersion:      dto.Metadata.DataVersion,
+			MatchId:          dto.Metadata.MatchID,
+			ParticipantPuuids: dto.Metadata.ParticipantPUUIDs,
+		},
+		Info: &tftv1.MatchInfo{
+			GameDatetime:   dto.Info.GameDatetime,
+			GameLength:     dto.Info.GameLength,
+			GameVersion:    dto.Info.GameVersion,
+			GameVariation:  dto.Info.GameVariation,
+			QueueId:        dto.Info.QueueID,
+			TftSetNumber:   dto.Info.TFTSetNumber,
+			TftSetCoreName: dto.Info.TFTSetCoreName,
+			TftGameType:    dto.Info.TFTGameType,
+			EndOfGameResult: dto.Info.EndOfGameResult,
+			Participants:   participants,
+		},
+	}
+}
+
+func mapParticipantToProto(p *riot.ParticipantDTO) *tftv1.Participant {
+	traits := make([]*tftv1.MatchTrait, 0, len(p.Traits))
+	for _, t := range p.Traits {
+		traits = append(traits, &tftv1.MatchTrait{
+			ApiName:     t.Name,
+			NumUnits:    t.NumUnits,
+			Style:       t.Style,
+			TierCurrent: t.TierCurrent,
+			TierTotal:   t.TierTotal,
+		})
+	}
+
+	units := make([]*tftv1.MatchUnit, 0, len(p.Units))
+	for _, u := range p.Units {
+		units = append(units, &tftv1.MatchUnit{
+			CharacterId: u.CharacterID,
+			Name:        u.Name,
+			Tier:        u.Tier,
+			Rarity:      u.Rarity,
+			ItemNames:   u.ItemNames,
+		})
+	}
+
+	augments := p.Augments
+	if augments == nil {
+		augments = []string{}
+	}
+
+	return &tftv1.Participant{
+		Puuid:                p.PUUID,
+		Placement:            p.Placement,
+		Level:                p.Level,
+		GoldLeft:             p.GoldLeft,
+		LastRound:            p.LastRound,
+		TimeEliminated:       p.TimeEliminated,
+		TotalDamageToPlayers: p.TotalDamageToPlayers,
+		PlayersEliminated:    p.PlayersEliminated,
+		PartnerGroupId:       p.PartnerGroupID,
+		Augments:             augments,
+		Companion: &tftv1.Companion{
+			ContentId: p.Companion.ContentID,
+			Species:   p.Companion.Species,
+			ItemId:    p.Companion.ItemID,
+			SkinId:    p.Companion.SkinID,
+		},
+		Traits: traits,
+		Units:  units,
+	}
+}
+
+// --- Riot DTO → JSONB (for DB storage) ---
+
+type dbTrait struct {
+	Name        string `json:"name"`
+	NumUnits    int32  `json:"num_units"`
+	Style       int32  `json:"style"`
+	TierCurrent int32  `json:"tier_current"`
+	TierTotal   int32  `json:"tier_total"`
+}
+
+type dbUnit struct {
+	CharacterID string   `json:"character_id"`
+	Name        string   `json:"name"`
+	Tier        int32    `json:"tier"`
+	Rarity      int32    `json:"rarity"`
+	ItemIDs     []int32  `json:"item_ids"`
+	Items       []string `json:"items"`
+}
+
+type dbCompanion struct {
+	ContentID string `json:"content_id"`
+	Species   string `json:"species"`
+	ItemID    int32  `json:"item_id"`
+	SkinID    int32  `json:"skin_id"`
+}
+
+func traitsToJSON(traits []riot.TraitDTO) ([]byte, error) {
+	dbTraits := make([]dbTrait, 0, len(traits))
+	for _, t := range traits {
+		dbTraits = append(dbTraits, dbTrait{
+			Name:        t.Name,
+			NumUnits:    t.NumUnits,
+			Style:       t.Style,
+			TierCurrent: t.TierCurrent,
+			TierTotal:   t.TierTotal,
+		})
+	}
+	return json.Marshal(dbTraits)
+}
+
+func unitsToJSON(units []riot.UnitDTO) ([]byte, error) {
+	dbUnits := make([]dbUnit, 0, len(units))
+	for _, u := range units {
+		itemNames := u.ItemNames
+		if itemNames == nil {
+			itemNames = []string{}
+		}
+		dbUnits = append(dbUnits, dbUnit{
+			CharacterID: u.CharacterID,
+			Name:        u.Name,
+			Tier:        u.Tier,
+			Rarity:      u.Rarity,
+			ItemIDs:     []int32{},
+			Items:       itemNames,
+		})
+	}
+	return json.Marshal(dbUnits)
+}
+
+func companionToJSON(c riot.CompanionDTO) ([]byte, error) {
+	return json.Marshal(dbCompanion{
+		ContentID: c.ContentID,
+		Species:   c.Species,
+		ItemID:    c.ItemID,
+		SkinID:    c.SkinID,
+	})
+}
+
+// --- DB → Proto (reconstructing match from stored data) ---
+
+func mapMatchFromDB(match generated.Match, participants []generated.MatchParticipant) *tftv1.Match {
+	pbParticipants := make([]*tftv1.Participant, 0, len(participants))
+	for _, p := range participants {
+		pbParticipants = append(pbParticipants, mapParticipantFromDB(p))
+	}
+
+	return &tftv1.Match{
+		Metadata: &tftv1.MatchMetadata{
+			DataVersion:      match.DataVersion,
+			MatchId:          match.MatchID,
+			ParticipantPuuids: match.ParticipantPuuids,
+		},
+		Info: &tftv1.MatchInfo{
+			GameDatetime: match.GameDatetime,
+			GameLength:   match.GameLength,
+			GameVersion:  match.GameVersion,
+			QueueId:      match.QueueID,
+			TftSetNumber: match.TftSetNumber,
+			TftGameType:  match.TftGameType,
+			Participants: pbParticipants,
+		},
+	}
+}
+
+func mapParticipantFromDB(p generated.MatchParticipant) *tftv1.Participant {
+	var traits []dbTrait
+	_ = json.Unmarshal(p.Traits, &traits)
+
+	var units []dbUnit
+	_ = json.Unmarshal(p.Units, &units)
+
+	var comp dbCompanion
+	_ = json.Unmarshal(p.Companion, &comp)
+
+	pbTraits := make([]*tftv1.MatchTrait, 0, len(traits))
+	for _, t := range traits {
+		pbTraits = append(pbTraits, &tftv1.MatchTrait{
+			ApiName:     t.Name,
+			NumUnits:    t.NumUnits,
+			Style:       t.Style,
+			TierCurrent: t.TierCurrent,
+			TierTotal:   t.TierTotal,
+		})
+	}
+
+	pbUnits := make([]*tftv1.MatchUnit, 0, len(units))
+	for _, u := range units {
+		pbUnits = append(pbUnits, &tftv1.MatchUnit{
+			CharacterId: u.CharacterID,
+			Name:        u.Name,
+			Tier:        u.Tier,
+			Rarity:      u.Rarity,
+			ItemIds:     u.ItemIDs,
+			ItemNames:   u.Items,
+		})
+	}
+
+	augments := p.Augments
+	if augments == nil {
+		augments = []string{}
+	}
+
+	return &tftv1.Participant{
+		Puuid:                p.Puuid,
+		Placement:            p.Placement,
+		Level:                p.Level,
+		GoldLeft:             p.GoldLeft,
+		LastRound:            p.LastRound,
+		TimeEliminated:       p.TimeEliminated,
+		TotalDamageToPlayers: p.TotalDamageToPlayers,
+		PlayersEliminated:    p.PlayersEliminated,
+		Augments:             augments,
+		Companion: &tftv1.Companion{
+			ContentId: comp.ContentID,
+			Species:   comp.Species,
+			ItemId:    comp.ItemID,
+			SkinId:    comp.SkinID,
+		},
+		Traits: pbTraits,
+		Units:  pbUnits,
+	}
+}

--- a/backend/internal/player/service.go
+++ b/backend/internal/player/service.go
@@ -2,31 +2,328 @@ package player
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"log"
 
 	"connectrpc.com/connect"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/sync/errgroup"
 
 	tftv1 "github.com/MeninoNias/tft-oracle/backend/gen/tft/v1"
 	"github.com/MeninoNias/tft-oracle/backend/gen/tft/v1/tftv1connect"
+	"github.com/MeninoNias/tft-oracle/backend/internal/cache"
+	"github.com/MeninoNias/tft-oracle/backend/internal/riot"
+	"github.com/MeninoNias/tft-oracle/backend/sqlc/generated"
 )
 
 var _ tftv1connect.PlayerServiceHandler = (*Service)(nil)
 
-type Service struct{}
+type Service struct {
+	db      *pgxpool.Pool
+	queries *generated.Queries
+	riot    *riot.Client
+	cache   *cache.Client // can be nil
+}
 
-func NewService() *Service {
-	return &Service{}
+func NewService(db *pgxpool.Pool, riotClient *riot.Client, cacheClient *cache.Client) *Service {
+	return &Service{
+		db:      db,
+		queries: generated.New(db),
+		riot:    riotClient,
+		cache:   cacheClient,
+	}
 }
 
 func (s *Service) GetPlayerProfile(
 	ctx context.Context,
 	req *connect.Request[tftv1.GetPlayerProfileRequest],
 ) (*connect.Response[tftv1.GetPlayerProfileResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+	gameName := req.Msg.GetGameName()
+	tagLine := req.Msg.GetTagLine()
+	region := req.Msg.GetRegion()
+
+	if gameName == "" || tagLine == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("game_name and tag_line are required"))
+	}
+	if region == "" {
+		region = "br"
+	}
+
+	// Resolve region → routing region + platform
+	server := riot.ResolveServer(region)
+
+	if !s.riot.Available() {
+		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("player features unavailable: RIOT_API_KEY not configured"))
+	}
+
+	// 1. Resolve PUUID (cache → Riot API)
+	puuid, err := s.cache.GetPUUID(ctx, gameName, tagLine)
+	if err != nil {
+		account, err := s.riot.GetAccountByRiotID(ctx, server.Region, gameName, tagLine)
+		if err != nil {
+			return nil, fmt.Errorf("get account: %w", err)
+		}
+		puuid = account.PUUID
+		s.cache.SetPUUID(ctx, gameName, tagLine, puuid)
+	}
+
+	// 3. Check profile cache
+	if cached, err := s.cache.GetPlayerProfile(ctx, puuid); err == nil {
+		var resp tftv1.GetPlayerProfileResponse
+		if json.Unmarshal(cached, &resp) == nil {
+			return connect.NewResponse(&resp), nil
+		}
+	}
+
+	// 4. Fetch summoner + league in parallel (both use platform routing)
+	var summoner *riot.SummonerDTO
+	var entries []riot.LeagueEntryDTO
+
+	g, gCtx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		var err error
+		summoner, err = s.riot.GetSummonerByPUUID(gCtx, server.Platform, puuid)
+		return err
+	})
+	g.Go(func() error {
+		var err error
+		entries, err = s.riot.GetLeagueByPUUID(gCtx, server.Platform, puuid)
+		return err
+	})
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("fetch profile: %w", err)
+	}
+
+	// 6. Build response
+	resp := &tftv1.GetPlayerProfileResponse{
+		Account: &tftv1.Account{
+			Puuid:    puuid,
+			GameName: gameName,
+			TagLine:  tagLine,
+		},
+		Summoner:      mapSummonerToProto(summoner),
+		RankedEntries: mapLeagueEntriesToProto(entries),
+	}
+
+	// 6. Cache profile
+	if data, err := json.Marshal(resp); err == nil {
+		s.cache.SetPlayerProfile(ctx, puuid, data)
+	}
+
+	// 7. Persist player in DB (best effort)
+	tier, rank, lp, wins, losses := extractRankedData(entries)
+	if _, err := s.queries.UpsertPlayer(ctx, generated.UpsertPlayerParams{
+		Puuid:         puuid,
+		GameName:      gameName,
+		TagLine:       tagLine,
+		Region:        server.Region,
+		Platform:      server.Platform,
+		SummonerID:    summoner.ID,
+		ProfileIconID: summoner.ProfileIconID,
+		SummonerLevel: summoner.SummonerLevel,
+		Tier:          tier,
+		Rank:          rank,
+		LeaguePoints:  lp,
+		Wins:          wins,
+		Losses:        losses,
+	}); err != nil {
+		log.Printf("warning: upsert player failed: %v", err)
+	}
+
+	return connect.NewResponse(resp), nil
 }
 
 func (s *Service) GetMatchHistory(
 	ctx context.Context,
 	req *connect.Request[tftv1.GetMatchHistoryRequest],
 ) (*connect.Response[tftv1.GetMatchHistoryResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+	puuid := req.Msg.GetPuuid()
+	region := req.Msg.GetRegion()
+	count := req.Msg.GetCount()
+	start := req.Msg.GetStart()
+
+	if puuid == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("puuid is required"))
+	}
+	if region == "" {
+		region = "br"
+	}
+	// Resolve to routing region for match API
+	server := riot.ResolveServer(region)
+	region = server.Region
+
+	if count == 0 {
+		count = 20
+	}
+	if count > 200 {
+		count = 200
+	}
+
+	if !s.riot.Available() {
+		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("player features unavailable: RIOT_API_KEY not configured"))
+	}
+
+	// 1. Get match IDs (cache → Riot API)
+	// Only use cache if it has enough IDs for the requested count
+	matchIDs, err := s.cache.GetMatchIDs(ctx, puuid)
+	if err != nil || int32(len(matchIDs)) < count {
+		matchIDs, err = s.riot.GetMatchIDsByPUUID(ctx, region, puuid, count, start)
+		if err != nil {
+			return nil, fmt.Errorf("get match ids: %w", err)
+		}
+		s.cache.SetMatchIDs(ctx, puuid, matchIDs)
+	}
+
+	// 2. Fetch each match (cache → DB → Riot API)
+	matches := make([]*tftv1.Match, 0, len(matchIDs))
+	for _, matchID := range matchIDs {
+		match, err := s.fetchMatch(ctx, region, matchID)
+		if err != nil {
+			log.Printf("warning: failed to fetch match %s: %v", matchID, err)
+			continue
+		}
+		matches = append(matches, match)
+	}
+
+	return connect.NewResponse(&tftv1.GetMatchHistoryResponse{
+		Matches: matches,
+	}), nil
+}
+
+// fetchMatch tries cache → DB → Riot API, persisting new matches.
+func (s *Service) fetchMatch(ctx context.Context, region, matchID string) (*tftv1.Match, error) {
+	// Try Redis cache
+	if cached, err := s.cache.GetMatchDetail(ctx, matchID); err == nil {
+		var dto riot.MatchDTO
+		if json.Unmarshal(cached, &dto) == nil {
+			return mapMatchToProto(&dto), nil
+		}
+	}
+
+	// Try DB
+	exists, err := s.queries.MatchExists(ctx, matchID)
+	if err == nil && exists {
+		return s.loadMatchFromDB(ctx, matchID)
+	}
+
+	// Fetch from Riot API
+	dto, err := s.riot.GetMatch(ctx, region, matchID)
+	if err != nil {
+		return nil, fmt.Errorf("fetch match: %w", err)
+	}
+
+	// Cache in Redis
+	if data, err := json.Marshal(dto); err == nil {
+		s.cache.SetMatchDetail(ctx, matchID, data)
+	}
+
+	// Persist in DB
+	if err := s.persistMatch(ctx, dto); err != nil {
+		log.Printf("warning: persist match %s failed: %v", matchID, err)
+	}
+
+	return mapMatchToProto(dto), nil
+}
+
+func (s *Service) loadMatchFromDB(ctx context.Context, matchID string) (*tftv1.Match, error) {
+	match, err := s.queries.GetMatchByID(ctx, matchID)
+	if err != nil {
+		return nil, fmt.Errorf("get match from db: %w", err)
+	}
+
+	participants, err := s.queries.GetParticipantsByMatch(ctx, matchID)
+	if err != nil {
+		return nil, fmt.Errorf("get participants from db: %w", err)
+	}
+
+	return mapMatchFromDB(match, participants), nil
+}
+
+func (s *Service) persistMatch(ctx context.Context, dto *riot.MatchDTO) error {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	qtx := s.queries.WithTx(tx)
+
+	puuids := dto.Metadata.ParticipantPUUIDs
+	if puuids == nil {
+		puuids = []string{}
+	}
+
+	_, err = qtx.UpsertMatch(ctx, generated.UpsertMatchParams{
+		MatchID:           dto.Metadata.MatchID,
+		DataVersion:       dto.Metadata.DataVersion,
+		GameDatetime:      dto.Info.GameDatetime,
+		GameLength:        dto.Info.GameLength,
+		GameVersion:       dto.Info.GameVersion,
+		QueueID:           dto.Info.QueueID,
+		TftSetNumber:      dto.Info.TFTSetNumber,
+		TftGameType:       dto.Info.TFTGameType,
+		ParticipantPuuids: puuids,
+	})
+	// UpsertMatch uses DO NOTHING — no row returned on conflict is expected (pgx.ErrNoRows)
+	if err != nil && err.Error() != "no rows in result set" {
+		return fmt.Errorf("upsert match: %w", err)
+	}
+
+	for _, p := range dto.Info.Participants {
+		traitsJSON, err := traitsToJSON(p.Traits)
+		if err != nil {
+			return fmt.Errorf("marshal traits: %w", err)
+		}
+
+		unitsJSON, err := unitsToJSON(p.Units)
+		if err != nil {
+			return fmt.Errorf("marshal units: %w", err)
+		}
+
+		companionJSON, err := companionToJSON(p.Companion)
+		if err != nil {
+			return fmt.Errorf("marshal companion: %w", err)
+		}
+
+		augments := p.Augments
+		if augments == nil {
+			augments = []string{}
+		}
+
+		err = qtx.UpsertMatchParticipant(ctx, generated.UpsertMatchParticipantParams{
+			MatchID:              dto.Metadata.MatchID,
+			Puuid:                p.PUUID,
+			Placement:            p.Placement,
+			Level:                p.Level,
+			GoldLeft:             p.GoldLeft,
+			LastRound:            p.LastRound,
+			TimeEliminated:       p.TimeEliminated,
+			TotalDamageToPlayers: p.TotalDamageToPlayers,
+			PlayersEliminated:    p.PlayersEliminated,
+			Augments:             augments,
+			Companion:            companionJSON,
+			Traits:               traitsJSON,
+			Units:                unitsJSON,
+		})
+		if err != nil {
+			return fmt.Errorf("upsert participant: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// extractRankedData finds the RANKED_TFT entry and returns tier/rank/lp/wins/losses.
+func extractRankedData(entries []riot.LeagueEntryDTO) (string, string, int32, int32, int32) {
+	for _, e := range entries {
+		if e.QueueType == "RANKED_TFT" {
+			return e.Tier, e.Rank, e.LeaguePoints, e.Wins, e.Losses
+		}
+	}
+	return "", "", 0, 0, 0
 }

--- a/backend/internal/riot/client.go
+++ b/backend/internal/riot/client.go
@@ -1,0 +1,186 @@
+package riot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"connectrpc.com/connect"
+	"golang.org/x/time/rate"
+)
+
+// Client is an HTTP client for the Riot Games API.
+type Client struct {
+	http    *http.Client
+	apiKey  string
+	limiter *rate.Limiter
+}
+
+// NewClient creates a new Riot API client.
+// apiKey can be empty — methods will return CodeUnavailable.
+func NewClient(apiKey string) *Client {
+	return &Client{
+		http: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+		apiKey: apiKey,
+		// Dev key limit: 20 requests per second, 100 per 2 minutes
+		limiter: rate.NewLimiter(rate.Every(50*time.Millisecond), 20),
+	}
+}
+
+// Available returns true if the Riot API key is configured.
+func (c *Client) Available() bool {
+	return c.apiKey != ""
+}
+
+// HealthCheck validates the API key by calling the Account V1 endpoint.
+func (c *Client) HealthCheck(ctx context.Context) error {
+	if !c.Available() {
+		return fmt.Errorf("RIOT_API_KEY not configured")
+	}
+
+	// Use a known-good endpoint to verify the key works.
+	// Account V1 on americas with a dummy lookup — 404 means key is valid, 401/403 means bad key.
+	testURL := "https://americas.api.riotgames.com/riot/account/v1/accounts/by-riot-id/healthcheck/test"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, testURL, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("X-Riot-Token", c.apiKey)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusNotFound:
+		// 200 = found (unlikely for healthcheck), 404 = not found (key is valid)
+		return nil
+	case http.StatusUnauthorized:
+		return fmt.Errorf("API key is invalid (401)")
+	case http.StatusForbidden:
+		return fmt.Errorf("API key is expired or forbidden (403)")
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+// --- Riot API Endpoints ---
+//
+// Routing:
+//   Account V1:       regional (americas, europe, asia, sea)
+//   TFT Summoner V1:  platform (br1, na1, euw1, kr, etc.)
+//   TFT League V1:    platform (br1, na1, euw1, kr, etc.)
+//   TFT Match V1:     regional (americas, europe, asia, sea)
+
+// GetAccountByRiotID looks up an account by Riot ID (Account V1, regional).
+func (c *Client) GetAccountByRiotID(ctx context.Context, region, gameName, tagLine string) (*AccountDTO, error) {
+	u := fmt.Sprintf("%s/riot/account/v1/accounts/by-riot-id/%s/%s",
+		RegionToBaseURL(region), url.PathEscape(gameName), url.PathEscape(tagLine))
+	var dto AccountDTO
+	if err := c.doGet(ctx, u, &dto); err != nil {
+		return nil, fmt.Errorf("get account by riot id: %w", err)
+	}
+	return &dto, nil
+}
+
+// GetSummonerByPUUID gets summoner data (TFT Summoner V1, platform).
+func (c *Client) GetSummonerByPUUID(ctx context.Context, platform, puuid string) (*SummonerDTO, error) {
+	u := fmt.Sprintf("%s/tft/summoner/v1/summoners/by-puuid/%s",
+		PlatformToBaseURL(platform), puuid)
+	var dto SummonerDTO
+	if err := c.doGet(ctx, u, &dto); err != nil {
+		return nil, fmt.Errorf("get summoner by puuid: %w", err)
+	}
+	return &dto, nil
+}
+
+// GetLeagueByPUUID gets ranked entries (TFT League V1, platform).
+func (c *Client) GetLeagueByPUUID(ctx context.Context, platform, puuid string) ([]LeagueEntryDTO, error) {
+	u := fmt.Sprintf("%s/tft/league/v1/by-puuid/%s",
+		PlatformToBaseURL(platform), puuid)
+	var dto []LeagueEntryDTO
+	if err := c.doGet(ctx, u, &dto); err != nil {
+		return nil, fmt.Errorf("get league entries: %w", err)
+	}
+	return dto, nil
+}
+
+// GetMatchIDsByPUUID gets recent match IDs (TFT Match V1, regional).
+func (c *Client) GetMatchIDsByPUUID(ctx context.Context, region, puuid string, count, start int32) ([]string, error) {
+	u := fmt.Sprintf("%s/tft/match/v1/matches/by-puuid/%s/ids?count=%d&start=%d",
+		RegionToBaseURL(region), puuid, count, start)
+	var ids []string
+	if err := c.doGet(ctx, u, &ids); err != nil {
+		return nil, fmt.Errorf("get match ids: %w", err)
+	}
+	return ids, nil
+}
+
+// GetMatch gets full match data (TFT Match V1, regional).
+func (c *Client) GetMatch(ctx context.Context, region, matchID string) (*MatchDTO, error) {
+	u := fmt.Sprintf("%s/tft/match/v1/matches/%s",
+		RegionToBaseURL(region), matchID)
+	var dto MatchDTO
+	if err := c.doGet(ctx, u, &dto); err != nil {
+		return nil, fmt.Errorf("get match %s: %w", matchID, err)
+	}
+	return &dto, nil
+}
+
+func (c *Client) doGet(ctx context.Context, url string, out interface{}) error {
+	if !c.Available() {
+		return connect.NewError(connect.CodeUnavailable, fmt.Errorf("RIOT_API_KEY not configured"))
+	}
+
+	if err := c.limiter.Wait(ctx); err != nil {
+		return fmt.Errorf("rate limiter: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("X-Riot-Token", c.apiKey)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return mapHTTPError(resp.StatusCode, body)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
+func mapHTTPError(status int, body []byte) error {
+	msg := string(body)
+	switch status {
+	case http.StatusNotFound:
+		return connect.NewError(connect.CodeNotFound, fmt.Errorf("not found: %s", msg))
+	case http.StatusForbidden:
+		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("forbidden: %s", msg))
+	case http.StatusUnauthorized:
+		return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("unauthorized: %s", msg))
+	case http.StatusTooManyRequests:
+		return connect.NewError(connect.CodeResourceExhausted, fmt.Errorf("rate limited: %s", msg))
+	default:
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("riot api error %d: %s", status, msg))
+	}
+}

--- a/backend/internal/riot/routing.go
+++ b/backend/internal/riot/routing.go
@@ -1,0 +1,95 @@
+package riot
+
+import "strings"
+
+// RegionToBaseURL maps a routing region to its base API URL.
+// Regional endpoints handle Account V1 and TFT Match V1.
+func RegionToBaseURL(region string) string {
+	switch strings.ToLower(region) {
+	case "americas":
+		return "https://americas.api.riotgames.com"
+	case "europe":
+		return "https://europe.api.riotgames.com"
+	case "asia":
+		return "https://asia.api.riotgames.com"
+	case "sea":
+		return "https://sea.api.riotgames.com"
+	default:
+		return "https://americas.api.riotgames.com"
+	}
+}
+
+// PlatformToBaseURL maps a platform to its base API URL.
+// Platform endpoints handle TFT Summoner V1 and TFT League V1.
+func PlatformToBaseURL(platform string) string {
+	return "https://" + strings.ToLower(platform) + ".api.riotgames.com"
+}
+
+// ServerInfo holds routing data for a player's server.
+type ServerInfo struct {
+	Region   string // Regional routing: "americas", "europe", "asia", "sea"
+	Platform string // Platform routing: "br1", "na1", "euw1", etc.
+}
+
+// serverMap maps user-facing server names to routing info.
+var serverMap = map[string]ServerInfo{
+	// Americas
+	"br":   {Region: "americas", Platform: "br1"},
+	"br1":  {Region: "americas", Platform: "br1"},
+	"na":   {Region: "americas", Platform: "na1"},
+	"na1":  {Region: "americas", Platform: "na1"},
+	"lan":  {Region: "americas", Platform: "la1"},
+	"la1":  {Region: "americas", Platform: "la1"},
+	"las":  {Region: "americas", Platform: "la2"},
+	"la2":  {Region: "americas", Platform: "la2"},
+	"oce":  {Region: "americas", Platform: "oc1"},
+	"oc1":  {Region: "americas", Platform: "oc1"},
+	// Europe
+	"euw":  {Region: "europe", Platform: "euw1"},
+	"euw1": {Region: "europe", Platform: "euw1"},
+	"eune": {Region: "europe", Platform: "eun1"},
+	"eun1": {Region: "europe", Platform: "eun1"},
+	"tr":   {Region: "europe", Platform: "tr1"},
+	"tr1":  {Region: "europe", Platform: "tr1"},
+	"ru":   {Region: "europe", Platform: "ru"},
+	// Asia
+	"kr":  {Region: "asia", Platform: "kr"},
+	"jp":  {Region: "asia", Platform: "jp1"},
+	"jp1": {Region: "asia", Platform: "jp1"},
+	// SEA
+	"ph":  {Region: "sea", Platform: "ph2"},
+	"ph2": {Region: "sea", Platform: "ph2"},
+	"sg":  {Region: "sea", Platform: "sg2"},
+	"sg2": {Region: "sea", Platform: "sg2"},
+	"th":  {Region: "sea", Platform: "th2"},
+	"th2": {Region: "sea", Platform: "th2"},
+	"tw":  {Region: "sea", Platform: "tw2"},
+	"tw2": {Region: "sea", Platform: "tw2"},
+	"vn":  {Region: "sea", Platform: "vn2"},
+	"vn2": {Region: "sea", Platform: "vn2"},
+}
+
+// ResolveServer looks up routing info from a server/region string.
+// Accepts platform codes ("br1"), short names ("br"), or region names ("americas").
+// For broad region names without a platform, defaults to the most common platform.
+func ResolveServer(input string) ServerInfo {
+	lower := strings.ToLower(strings.TrimSpace(input))
+
+	if info, ok := serverMap[lower]; ok {
+		return info
+	}
+
+	// Fallback: treat as broad region name
+	switch lower {
+	case "americas":
+		return ServerInfo{Region: "americas", Platform: "na1"}
+	case "europe":
+		return ServerInfo{Region: "europe", Platform: "euw1"}
+	case "asia":
+		return ServerInfo{Region: "asia", Platform: "kr"}
+	case "sea":
+		return ServerInfo{Region: "sea", Platform: "sg2"}
+	default:
+		return ServerInfo{Region: "americas", Platform: "na1"}
+	}
+}

--- a/backend/internal/riot/types.go
+++ b/backend/internal/riot/types.go
@@ -1,0 +1,112 @@
+package riot
+
+// AccountDTO represents a Riot Account (Account V1).
+type AccountDTO struct {
+	PUUID    string `json:"puuid"`
+	GameName string `json:"gameName"`
+	TagLine  string `json:"tagLine"`
+}
+
+// SummonerDTO represents a TFT Summoner (TFT Summoner V1).
+type SummonerDTO struct {
+	ID            string `json:"id"`
+	AccountID     string `json:"accountId"`
+	PUUID         string `json:"puuid"`
+	ProfileIconID int32  `json:"profileIconId"`
+	SummonerLevel int64  `json:"summonerLevel"`
+	RevisionDate  int64  `json:"revisionDate"`
+}
+
+// LeagueEntryDTO represents a ranked league entry (TFT League V1).
+type LeagueEntryDTO struct {
+	QueueType    string        `json:"queueType"`
+	Tier         string        `json:"tier"`
+	Rank         string        `json:"rank"`
+	LeaguePoints int32         `json:"leaguePoints"`
+	Wins         int32         `json:"wins"`
+	Losses       int32         `json:"losses"`
+	HotStreak    bool          `json:"hotStreak"`
+	Veteran      bool          `json:"veteran"`
+	FreshBlood   bool          `json:"freshBlood"`
+	Inactive     bool          `json:"inactive"`
+	SummonerID   string        `json:"summonerId"`
+	MiniSeries   *MiniSeriesDTO `json:"miniSeries,omitempty"`
+}
+
+// MiniSeriesDTO represents a promotion series.
+type MiniSeriesDTO struct {
+	Progress string `json:"progress"`
+	Wins     int32  `json:"wins"`
+	Losses   int32  `json:"losses"`
+	Target   int32  `json:"target"`
+}
+
+// MatchDTO represents a full TFT match (TFT Match V1).
+type MatchDTO struct {
+	Metadata MatchMetadataDTO `json:"metadata"`
+	Info     MatchInfoDTO     `json:"info"`
+}
+
+// MatchMetadataDTO contains match metadata.
+type MatchMetadataDTO struct {
+	DataVersion      string   `json:"data_version"`
+	MatchID          string   `json:"match_id"`
+	ParticipantPUUIDs []string `json:"participants"`
+}
+
+// MatchInfoDTO contains match gameplay data.
+type MatchInfoDTO struct {
+	GameDatetime   int64            `json:"game_datetime"`
+	GameLength     float32          `json:"game_length"`
+	GameVersion    string           `json:"game_version"`
+	GameVariation  string           `json:"game_variation"`
+	QueueID        int32            `json:"queue_id"`
+	TFTSetNumber   int32            `json:"tft_set_number"`
+	TFTSetCoreName string           `json:"tft_set_core_name"`
+	TFTGameType    string           `json:"tft_game_type"`
+	EndOfGameResult string          `json:"endOfGameResult"`
+	Participants   []ParticipantDTO `json:"participants"`
+}
+
+// ParticipantDTO represents a participant in a match.
+type ParticipantDTO struct {
+	PUUID                string        `json:"puuid"`
+	Placement            int32         `json:"placement"`
+	Level                int32         `json:"level"`
+	GoldLeft             int32         `json:"gold_left"`
+	LastRound            int32         `json:"last_round"`
+	TimeEliminated       float32       `json:"time_eliminated"`
+	TotalDamageToPlayers int32         `json:"total_damage_to_players"`
+	PlayersEliminated    int32         `json:"players_eliminated"`
+	PartnerGroupID       int32         `json:"partner_group_id"`
+	Augments             []string      `json:"augments"`
+	Companion            CompanionDTO  `json:"companion"`
+	Traits               []TraitDTO    `json:"traits"`
+	Units                []UnitDTO     `json:"units"`
+}
+
+// CompanionDTO represents a Little Legend.
+type CompanionDTO struct {
+	ContentID string `json:"content_ID"`
+	Species   string `json:"species"`
+	ItemID    int32  `json:"item_ID"`
+	SkinID    int32  `json:"skin_ID"`
+}
+
+// TraitDTO represents a trait in a match.
+type TraitDTO struct {
+	Name        string `json:"name"`
+	NumUnits    int32  `json:"num_units"`
+	Style       int32  `json:"style"`
+	TierCurrent int32  `json:"tier_current"`
+	TierTotal   int32  `json:"tier_total"`
+}
+
+// UnitDTO represents a unit on a player's board.
+type UnitDTO struct {
+	CharacterID string   `json:"character_id"`
+	Name        string   `json:"name"`
+	Tier        int32    `json:"tier"`
+	Rarity      int32    `json:"rarity"`
+	ItemNames   []string `json:"itemNames"` // Item apiName strings (e.g. "TFT_Item_BFSword")
+}

--- a/backend/sqlc/queries/champions.sql
+++ b/backend/sqlc/queries/champions.sql
@@ -18,3 +18,6 @@ SELECT * FROM champions WHERE set_number = $1 ORDER BY cost, name;
 
 -- name: GetChampionByApiName :one
 SELECT * FROM champions WHERE api_name = $1 AND set_number = $2;
+
+-- name: DeleteChampionsBySet :exec
+DELETE FROM champions WHERE set_number = $1;

--- a/backend/sqlc/queries/items.sql
+++ b/backend/sqlc/queries/items.sql
@@ -16,3 +16,6 @@ RETURNING *;
 
 -- name: GetItemsBySet :many
 SELECT * FROM items WHERE set_number = $1 ORDER BY name;
+
+-- name: DeleteItemsBySet :exec
+DELETE FROM items WHERE set_number = $1;

--- a/backend/sqlc/queries/match_participants.sql
+++ b/backend/sqlc/queries/match_participants.sql
@@ -1,0 +1,26 @@
+-- name: UpsertMatchParticipant :exec
+INSERT INTO match_participants (
+    match_id, puuid, placement, level, gold_left, last_round,
+    time_eliminated, total_damage_to_players, players_eliminated,
+    augments, companion, traits, units
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
+)
+ON CONFLICT (match_id, puuid) DO NOTHING;
+
+-- name: GetParticipantsByMatch :many
+SELECT * FROM match_participants WHERE match_id = $1 ORDER BY placement;
+
+-- name: GetParticipantsByPUUID :many
+SELECT mp.* FROM match_participants mp
+JOIN matches m ON mp.match_id = m.match_id
+WHERE mp.puuid = $1
+ORDER BY m.game_datetime DESC
+LIMIT $2 OFFSET $3;
+
+-- name: GetPlacementDistribution :many
+SELECT placement, COUNT(*) as count
+FROM match_participants
+WHERE puuid = $1
+GROUP BY placement
+ORDER BY placement;

--- a/backend/sqlc/queries/matches.sql
+++ b/backend/sqlc/queries/matches.sql
@@ -1,0 +1,22 @@
+-- name: UpsertMatch :one
+INSERT INTO matches (
+    match_id, data_version, game_datetime, game_length,
+    game_version, queue_id, tft_set_number, tft_game_type,
+    participant_puuids
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
+)
+ON CONFLICT (match_id) DO NOTHING
+RETURNING *;
+
+-- name: GetMatchByID :one
+SELECT * FROM matches WHERE match_id = $1;
+
+-- name: GetMatchesByPUUID :many
+SELECT m.* FROM matches m
+WHERE m.participant_puuids @> ARRAY[$1]::TEXT[]
+ORDER BY m.game_datetime DESC
+LIMIT $2 OFFSET $3;
+
+-- name: MatchExists :one
+SELECT EXISTS(SELECT 1 FROM matches WHERE match_id = $1);

--- a/backend/sqlc/queries/players.sql
+++ b/backend/sqlc/queries/players.sql
@@ -1,0 +1,29 @@
+-- name: UpsertPlayer :one
+INSERT INTO players (
+    puuid, game_name, tag_line, region, platform, summoner_id,
+    profile_icon_id, summoner_level, tier, rank, league_points,
+    wins, losses, updated_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW()
+)
+ON CONFLICT (puuid) DO UPDATE SET
+    game_name = EXCLUDED.game_name,
+    tag_line = EXCLUDED.tag_line,
+    region = EXCLUDED.region,
+    platform = EXCLUDED.platform,
+    summoner_id = EXCLUDED.summoner_id,
+    profile_icon_id = EXCLUDED.profile_icon_id,
+    summoner_level = EXCLUDED.summoner_level,
+    tier = EXCLUDED.tier,
+    rank = EXCLUDED.rank,
+    league_points = EXCLUDED.league_points,
+    wins = EXCLUDED.wins,
+    losses = EXCLUDED.losses,
+    updated_at = NOW()
+RETURNING *;
+
+-- name: GetPlayerByPUUID :one
+SELECT * FROM players WHERE puuid = $1;
+
+-- name: GetPlayerByRiotID :one
+SELECT * FROM players WHERE game_name = $1 AND tag_line = $2;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from "react-router-dom";
 import { MainLayout } from "./components/layout/main-layout";
 import { ChampionsPage } from "./pages/champions";
 import { ItemsPage } from "./pages/items";
+import { PlayerPage } from "./pages/player";
 
 export function App() {
   return (
@@ -10,6 +11,7 @@ export function App() {
         <Route path="/" element={<Navigate to="/champions" replace />} />
         <Route path="/champions" element={<ChampionsPage />} />
         <Route path="/items" element={<ItemsPage />} />
+        <Route path="/player" element={<PlayerPage />} />
       </Routes>
     </MainLayout>
   );

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -3,6 +3,7 @@ import { NavLink } from "react-router-dom";
 const navItems = [
   { to: "/champions", label: "champions" },
   { to: "/items", label: "items" },
+  { to: "/player", label: "player" },
 ];
 
 export function Sidebar() {
@@ -12,7 +13,7 @@ export function Sidebar() {
         <h1 className="text-sm font-bold tracking-wider text-white">
           TFT_ORACLE
         </h1>
-        <p className="mt-0.5 text-[10px] text-lofi-muted">v0.1.0 // phase 1</p>
+        <p className="mt-0.5 text-[10px] text-lofi-muted">v0.2.0 // phase 2</p>
       </div>
 
       <nav className="flex-1 px-2 py-3">
@@ -44,7 +45,7 @@ export function Sidebar() {
 
       <div className="border-t border-lofi-border px-4 py-3">
         <p className="text-[10px] text-lofi-muted">
-          data: communitydragon
+          data: communitydragon + riot api
         </p>
       </div>
     </aside>

--- a/frontend/src/components/player/analytics-panel.tsx
+++ b/frontend/src/components/player/analytics-panel.tsx
@@ -1,0 +1,236 @@
+import { useMemo } from "react";
+import { TerminalCard } from "@/components/ui/terminal-card";
+import type { Match } from "@/gen/tft/v1/player_pb";
+
+interface AnalyticsPanelProps {
+  matches: Match[];
+  puuid: string;
+}
+
+interface TraitStat {
+  apiName: string;
+  games: number;
+  avgPlacement: number;
+  top4Count: number;
+}
+
+interface ChampionStat {
+  characterId: string;
+  games: number;
+  avgPlacement: number;
+}
+
+export function AnalyticsPanel({ matches, puuid }: AnalyticsPanelProps) {
+  const stats = useMemo(() => {
+    const placements: number[] = [];
+    const traitMap = new Map<
+      string,
+      { games: number; totalPlacement: number; top4: number }
+    >();
+    const champMap = new Map<
+      string,
+      { games: number; totalPlacement: number }
+    >();
+
+    for (const match of matches) {
+      const p = match.info?.participants.find((p) => p.puuid === puuid);
+      if (!p) continue;
+
+      placements.push(p.placement);
+
+      for (const trait of p.traits) {
+        if (trait.style === 0) continue;
+        const existing = traitMap.get(trait.apiName) ?? {
+          games: 0,
+          totalPlacement: 0,
+          top4: 0,
+        };
+        existing.games++;
+        existing.totalPlacement += p.placement;
+        if (p.placement <= 4) existing.top4++;
+        traitMap.set(trait.apiName, existing);
+      }
+
+      for (const unit of p.units) {
+        const existing = champMap.get(unit.characterId) ?? {
+          games: 0,
+          totalPlacement: 0,
+        };
+        existing.games++;
+        existing.totalPlacement += p.placement;
+        champMap.set(unit.characterId, existing);
+      }
+    }
+
+    const avgPlacement =
+      placements.length > 0
+        ? placements.reduce((a, b) => a + b, 0) / placements.length
+        : 0;
+    const top4Rate =
+      placements.length > 0
+        ? (placements.filter((p) => p <= 4).length / placements.length) * 100
+        : 0;
+    const winRate =
+      placements.length > 0
+        ? (placements.filter((p) => p === 1).length / placements.length) * 100
+        : 0;
+
+    const placementDist = Array.from({ length: 8 }, (_, i) => ({
+      placement: i + 1,
+      count: placements.filter((p) => p === i + 1).length,
+    }));
+
+    const topTraits: TraitStat[] = Array.from(traitMap.entries())
+      .map(([apiName, data]) => ({
+        apiName,
+        games: data.games,
+        avgPlacement: data.totalPlacement / data.games,
+        top4Count: data.top4,
+      }))
+      .sort((a, b) => b.games - a.games)
+      .slice(0, 5);
+
+    const topChampions: ChampionStat[] = Array.from(champMap.entries())
+      .map(([characterId, data]) => ({
+        characterId,
+        games: data.games,
+        avgPlacement: data.totalPlacement / data.games,
+      }))
+      .sort((a, b) => b.games - a.games)
+      .slice(0, 5);
+
+    return {
+      avgPlacement,
+      top4Rate,
+      winRate,
+      placementDist,
+      topTraits,
+      topChampions,
+      totalGames: placements.length,
+    };
+  }, [matches, puuid]);
+
+  if (stats.totalGames === 0) return null;
+
+  const maxCount = Math.max(...stats.placementDist.map((d) => d.count), 1);
+
+  return (
+    <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+      {/* Overview */}
+      <TerminalCard>
+        <h3 className="mb-2 text-[10px] uppercase tracking-wider text-lofi-muted">
+          overview // {stats.totalGames} games
+        </h3>
+        <div className="space-y-1.5">
+          <StatRow label="avg placement" value={stats.avgPlacement.toFixed(2)} />
+          <StatRow label="top 4 rate" value={`${stats.top4Rate.toFixed(1)}%`} />
+          <StatRow label="win rate" value={`${stats.winRate.toFixed(1)}%`} />
+        </div>
+
+        <h3 className="mb-2 mt-4 text-[10px] uppercase tracking-wider text-lofi-muted">
+          placement distribution
+        </h3>
+        <div className="space-y-1">
+          {stats.placementDist.map((d) => (
+            <div key={d.placement} className="flex items-center gap-2">
+              <span className="w-4 text-right text-[10px] text-lofi-secondary">
+                {d.placement}
+              </span>
+              <div className="h-3 flex-1 overflow-hidden rounded-sm bg-lofi-black">
+                <div
+                  className={`h-full rounded-sm ${d.placement <= 4 ? "bg-green-500/40" : "bg-red-500/30"}`}
+                  style={{ width: `${(d.count / maxCount) * 100}%` }}
+                />
+              </div>
+              <span className="w-5 text-right text-[10px] text-lofi-muted">
+                {d.count}
+              </span>
+            </div>
+          ))}
+        </div>
+      </TerminalCard>
+
+      {/* Top Traits */}
+      <TerminalCard>
+        <h3 className="mb-2 text-[10px] uppercase tracking-wider text-lofi-muted">
+          top traits
+        </h3>
+        {stats.topTraits.length === 0 && (
+          <p className="text-[10px] text-lofi-muted">no data</p>
+        )}
+        <div className="space-y-2">
+          {stats.topTraits.map((trait) => (
+            <div
+              key={trait.apiName}
+              className="flex items-center justify-between"
+            >
+              <div>
+                <span className="text-xs text-lofi-text">
+                  {formatName(trait.apiName)}
+                </span>
+                <span className="ml-2 text-[10px] text-lofi-muted">
+                  {trait.games} games
+                </span>
+              </div>
+              <div className="text-right">
+                <span className="text-[10px] text-lofi-secondary">
+                  avg {trait.avgPlacement.toFixed(1)}
+                </span>
+                <span className="ml-2 text-[10px] text-lofi-muted">
+                  top4{" "}
+                  {((trait.top4Count / trait.games) * 100).toFixed(0)}%
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </TerminalCard>
+
+      {/* Top Champions */}
+      <TerminalCard>
+        <h3 className="mb-2 text-[10px] uppercase tracking-wider text-lofi-muted">
+          top champions
+        </h3>
+        {stats.topChampions.length === 0 && (
+          <p className="text-[10px] text-lofi-muted">no data</p>
+        )}
+        <div className="space-y-2">
+          {stats.topChampions.map((champ) => (
+            <div
+              key={champ.characterId}
+              className="flex items-center justify-between"
+            >
+              <div>
+                <span className="text-xs text-lofi-text">
+                  {formatName(champ.characterId)}
+                </span>
+                <span className="ml-2 text-[10px] text-lofi-muted">
+                  {champ.games} games
+                </span>
+              </div>
+              <span className="text-[10px] text-lofi-secondary">
+                avg {champ.avgPlacement.toFixed(1)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </TerminalCard>
+    </div>
+  );
+}
+
+function StatRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-[10px] text-lofi-secondary">{label}</span>
+      <span className="text-xs font-bold text-white">{value}</span>
+    </div>
+  );
+}
+
+function formatName(apiName: string): string {
+  return apiName
+    .replace(/^Set\d+_/, "")
+    .replace(/^TFT\d+_/, "")
+    .replace(/^TFT_/, "");
+}

--- a/frontend/src/components/player/match-card.tsx
+++ b/frontend/src/components/player/match-card.tsx
@@ -1,0 +1,142 @@
+import { useState } from "react";
+import { TerminalCard } from "@/components/ui/terminal-card";
+import { PlacementBadge } from "@/components/player/placement-badge";
+import { UnitIcon } from "@/components/player/unit-icon";
+import { TraitBadge } from "@/components/player/trait-badge";
+import { MatchDetail } from "@/components/player/match-detail";
+import type { Match } from "@/gen/tft/v1/player_pb";
+import type { PatchLookup } from "@/hooks/use-patch-lookup";
+
+interface MatchCardProps {
+  match: Match;
+  playerPuuid: string;
+  patchLookup: PatchLookup;
+}
+
+export function MatchCard({
+  match,
+  playerPuuid,
+  patchLookup,
+}: MatchCardProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const info = match.info;
+  const metadata = match.metadata;
+  if (!info || !metadata) return null;
+
+  const player = info.participants.find((p) => p.puuid === playerPuuid);
+  if (!player) return null;
+
+  const gameDate = new Date(Number(info.gameDatetime));
+  const timeAgo = getTimeAgo(gameDate);
+  const gameLengthMin = (info.gameLength / 60).toFixed(0);
+  const roundStr = formatRound(player.lastRound);
+
+  const activeTraits = player.traits
+    .filter((t) => t.style > 0)
+    .sort((a, b) => b.style - a.style);
+
+  const sortedUnits = [...player.units].sort(
+    (a, b) => b.rarity - a.rarity || b.tier - a.tier,
+  );
+
+  return (
+    <div>
+      <TerminalCard
+        className={`cursor-pointer transition-colors hover:border-lofi-muted ${
+          player.placement <= 4
+            ? "border-l-2 border-l-green-500/40"
+            : "border-l-2 border-l-red-500/30"
+        }`}
+      >
+        <div onClick={() => setExpanded(!expanded)}>
+          <div className="flex items-center gap-4">
+            {/* Placement */}
+            <PlacementBadge
+              placement={player.placement}
+              size="md"
+              className="shrink-0"
+            />
+
+            {/* Meta info */}
+            <div className="w-[120px] shrink-0 space-y-0.5">
+              <p className="text-xs font-medium text-lofi-secondary">
+                {info.tftGameType === "standard" ? "ranked" : info.tftGameType}
+              </p>
+              <p className="text-xs text-lofi-muted">
+                {timeAgo} // {gameLengthMin}m
+              </p>
+              <p className="text-xs text-lofi-muted">
+                lv{player.level} // {roundStr}
+              </p>
+              <div className="flex items-center gap-2">
+                <span
+                  className="text-xs text-lofi-secondary"
+                  title="damage dealt"
+                >
+                  ⚔ {player.totalDamageToPlayers}
+                </span>
+                {player.playersEliminated > 0 && (
+                  <span className="text-xs font-medium text-red-400">
+                    {player.playersEliminated} kill
+                    {player.playersEliminated > 1 ? "s" : ""}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {/* Traits */}
+            <div className="flex w-[150px] shrink-0 flex-wrap content-start gap-1">
+              {activeTraits.slice(0, 8).map((trait) => (
+                <TraitBadge
+                  key={trait.apiName}
+                  trait={trait}
+                  lookup={patchLookup}
+                />
+              ))}
+            </div>
+
+            {/* Units */}
+            <div className="flex min-w-0 flex-1 items-start gap-1.5 overflow-x-auto">
+              {sortedUnits.map((unit, i) => (
+                <UnitIcon key={i} unit={unit} lookup={patchLookup} />
+              ))}
+            </div>
+
+            {/* Expand */}
+            <button className="shrink-0 px-1 text-xs text-lofi-muted hover:text-lofi-text">
+              {expanded ? "▲" : "▼"}
+            </button>
+          </div>
+        </div>
+      </TerminalCard>
+
+      {expanded && (
+        <MatchDetail
+          match={match}
+          playerPuuid={playerPuuid}
+          patchLookup={patchLookup}
+        />
+      )}
+    </div>
+  );
+}
+
+function formatRound(lastRound: number): string {
+  if (lastRound <= 3) return `1-${lastRound}`;
+  const adjusted = lastRound - 3;
+  const stage = Math.floor(adjusted / 7) + 2;
+  const round = (adjusted % 7) + 1;
+  return `${stage}-${round}`;
+}
+
+function getTimeAgo(date: Date): string {
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/frontend/src/components/player/match-detail.tsx
+++ b/frontend/src/components/player/match-detail.tsx
@@ -1,0 +1,77 @@
+import { TerminalCard } from "@/components/ui/terminal-card";
+import { PlacementBadge } from "@/components/player/placement-badge";
+import { UnitIcon } from "@/components/player/unit-icon";
+import { TraitBadge } from "@/components/player/trait-badge";
+import type { Match } from "@/gen/tft/v1/player_pb";
+import type { PatchLookup } from "@/hooks/use-patch-lookup";
+
+interface MatchDetailProps {
+  match: Match;
+  playerPuuid: string;
+  patchLookup: PatchLookup;
+}
+
+export function MatchDetail({
+  match,
+  playerPuuid,
+  patchLookup,
+}: MatchDetailProps) {
+  const info = match.info;
+  if (!info) return null;
+
+  const sorted = [...info.participants].sort(
+    (a, b) => a.placement - b.placement,
+  );
+
+  return (
+    <TerminalCard className="mt-1 rounded-t-none border-t-0">
+      <div className="space-y-2">
+        {sorted.map((p) => {
+          const isPlayer = p.puuid === playerPuuid;
+          const activeTraits = p.traits
+            .filter((t) => t.style > 0)
+            .sort((a, b) => b.style - a.style);
+          const sortedUnits = [...p.units].sort(
+            (a, b) => b.rarity - a.rarity || b.tier - a.tier,
+          );
+
+          return (
+            <div
+              key={p.puuid}
+              className={`flex items-center gap-3 rounded-sm p-2 ${
+                isPlayer ? "bg-lofi-accent/10" : ""
+              }`}
+            >
+              <PlacementBadge placement={p.placement} />
+
+              <div className="w-[80px] shrink-0 space-y-0.5">
+                <p className="text-xs text-lofi-muted">
+                  lv{p.level} // {p.goldLeft}g
+                </p>
+                <p className="text-xs text-lofi-muted">
+                  ⚔ {p.totalDamageToPlayers}
+                </p>
+              </div>
+
+              <div className="flex w-[110px] shrink-0 flex-wrap gap-0.5">
+                {activeTraits.slice(0, 5).map((trait) => (
+                  <TraitBadge
+                    key={trait.apiName}
+                    trait={trait}
+                    lookup={patchLookup}
+                  />
+                ))}
+              </div>
+
+              <div className="flex min-w-0 flex-1 items-start gap-1 overflow-x-auto">
+                {sortedUnits.map((unit, i) => (
+                  <UnitIcon key={i} unit={unit} lookup={patchLookup} />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </TerminalCard>
+  );
+}

--- a/frontend/src/components/player/placement-badge.tsx
+++ b/frontend/src/components/player/placement-badge.tsx
@@ -1,0 +1,39 @@
+interface PlacementBadgeProps {
+  placement: number;
+  size?: "sm" | "md";
+  className?: string;
+}
+
+const placementColors: Record<number, string> = {
+  1: "bg-yellow-500/20 text-yellow-400 border-yellow-500/40",
+  2: "bg-gray-300/20 text-gray-300 border-gray-400/40",
+  3: "bg-amber-600/20 text-amber-500 border-amber-600/40",
+  4: "bg-green-500/20 text-green-400 border-green-500/40",
+  5: "bg-red-400/10 text-red-400/80 border-red-400/30",
+  6: "bg-red-400/10 text-red-400/80 border-red-400/30",
+  7: "bg-red-500/10 text-red-500/80 border-red-500/30",
+  8: "bg-red-600/10 text-red-500 border-red-600/30",
+};
+
+const sizes = {
+  sm: "h-8 w-8 text-sm font-bold",
+  md: "h-11 w-11 text-xl font-bold",
+};
+
+export function PlacementBadge({
+  placement,
+  size = "sm",
+  className = "",
+}: PlacementBadgeProps) {
+  const color =
+    placementColors[placement] ??
+    "bg-lofi-surface text-lofi-muted border-lofi-border";
+
+  return (
+    <span
+      className={`inline-flex items-center justify-center rounded-sm border ${sizes[size]} ${color} ${className}`}
+    >
+      {placement}
+    </span>
+  );
+}

--- a/frontend/src/components/player/profile-header.tsx
+++ b/frontend/src/components/player/profile-header.tsx
@@ -1,0 +1,78 @@
+import { TerminalCard } from "@/components/ui/terminal-card";
+import type {
+  Account,
+  Summoner,
+  RankedEntry,
+} from "@/gen/tft/v1/player_pb";
+
+interface ProfileHeaderProps {
+  account: Account;
+  summoner?: Summoner;
+  rankedEntries: RankedEntry[];
+}
+
+const tierColors: Record<string, string> = {
+  IRON: "text-gray-400",
+  BRONZE: "text-amber-700",
+  SILVER: "text-gray-300",
+  GOLD: "text-yellow-400",
+  PLATINUM: "text-teal-400",
+  EMERALD: "text-emerald-400",
+  DIAMOND: "text-blue-400",
+  MASTER: "text-purple-400",
+  GRANDMASTER: "text-red-400",
+  CHALLENGER: "text-yellow-300",
+};
+
+export function ProfileHeader({
+  account,
+  summoner,
+  rankedEntries,
+}: ProfileHeaderProps) {
+  const ranked = rankedEntries.find((e) => e.queueType === "RANKED_TFT");
+  const totalGames = ranked ? ranked.wins + ranked.losses : 0;
+  const winRate =
+    totalGames > 0 ? ((ranked!.wins / totalGames) * 100).toFixed(1) : "0";
+
+  return (
+    <TerminalCard className="border-l-2 border-l-lofi-accent">
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="flex items-baseline gap-2">
+            <h2 className="text-sm font-bold text-white">
+              {account.gameName}
+            </h2>
+            <span className="text-[10px] text-lofi-muted">
+              #{account.tagLine}
+            </span>
+          </div>
+          {summoner && (
+            <p className="mt-0.5 text-[10px] text-lofi-muted">
+              level {Number(summoner.summonerLevel)}
+            </p>
+          )}
+        </div>
+
+        {ranked && (
+          <div className="text-right">
+            <p
+              className={`text-sm font-bold ${tierColors[ranked.tier] ?? "text-lofi-text"}`}
+            >
+              {ranked.tier} {ranked.rank}
+            </p>
+            <p className="text-[10px] text-lofi-secondary">
+              {ranked.leaguePoints} LP
+            </p>
+            <p className="mt-0.5 text-[10px] text-lofi-muted">
+              {ranked.wins}W {ranked.losses}L ({winRate}%)
+            </p>
+          </div>
+        )}
+
+        {!ranked && (
+          <p className="text-[10px] text-lofi-muted">unranked</p>
+        )}
+      </div>
+    </TerminalCard>
+  );
+}

--- a/frontend/src/components/player/riot-id-form.tsx
+++ b/frontend/src/components/player/riot-id-form.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const servers = [
+  { value: "br", label: "BR" },
+  { value: "na", label: "NA" },
+  { value: "lan", label: "LAN" },
+  { value: "las", label: "LAS" },
+  { value: "oce", label: "OCE" },
+  { value: "euw", label: "EUW" },
+  { value: "eune", label: "EUNE" },
+  { value: "tr", label: "TR" },
+  { value: "ru", label: "RU" },
+  { value: "kr", label: "KR" },
+  { value: "jp", label: "JP" },
+  { value: "ph", label: "PH" },
+  { value: "sg", label: "SG" },
+  { value: "th", label: "TH" },
+  { value: "tw", label: "TW" },
+  { value: "vn", label: "VN" },
+];
+
+interface RiotIdFormProps {
+  onSubmit: (gameName: string, tagLine: string, region: string) => void;
+  isLoading?: boolean;
+}
+
+export function RiotIdForm({ onSubmit, isLoading }: RiotIdFormProps) {
+  const [gameName, setGameName] = useState("");
+  const [tagLine, setTagLine] = useState("");
+  const [region, setRegion] = useState("br");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (gameName.trim() && tagLine.trim()) {
+      onSubmit(gameName.trim(), tagLine.trim(), region);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-wrap items-end gap-3">
+      <div className="min-w-[140px] flex-1">
+        <label className="mb-1 block text-[10px] uppercase tracking-wider text-lofi-muted">
+          game name
+        </label>
+        <Input
+          value={gameName}
+          onChange={(e) => setGameName(e.target.value)}
+          placeholder="MeninoNias"
+          disabled={isLoading}
+        />
+      </div>
+      <div className="w-24">
+        <label className="mb-1 block text-[10px] uppercase tracking-wider text-lofi-muted">
+          tag line
+        </label>
+        <Input
+          value={tagLine}
+          onChange={(e) => setTagLine(e.target.value)}
+          placeholder="BR1"
+          disabled={isLoading}
+        />
+      </div>
+      <div className="w-24">
+        <label className="mb-1 block text-[10px] uppercase tracking-wider text-lofi-muted">
+          server
+        </label>
+        <select
+          value={region}
+          onChange={(e) => setRegion(e.target.value)}
+          disabled={isLoading}
+          className="w-full rounded-sm border border-lofi-border bg-lofi-black px-3 py-1.5 text-xs text-lofi-text focus:border-lofi-accent focus:outline-none focus:ring-1 focus:ring-lofi-accent"
+        >
+          {servers.map((r) => (
+            <option key={r.value} value={r.value}>
+              {r.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <Button
+        type="submit"
+        disabled={isLoading || !gameName.trim() || !tagLine.trim()}
+      >
+        {isLoading ? "loading..." : "search"}
+      </Button>
+    </form>
+  );
+}

--- a/frontend/src/components/player/trait-badge.tsx
+++ b/frontend/src/components/player/trait-badge.tsx
@@ -1,0 +1,46 @@
+import type { PatchLookup } from "@/hooks/use-patch-lookup";
+import type { MatchTrait } from "@/gen/tft/v1/player_pb";
+
+interface TraitBadgeProps {
+  trait: MatchTrait;
+  lookup: PatchLookup;
+}
+
+const styleColors: Record<number, string> = {
+  1: "bg-amber-900/30 border-amber-700/50 text-amber-500",
+  2: "bg-gray-400/20 border-gray-400/50 text-gray-300",
+  3: "bg-yellow-500/20 border-yellow-500/50 text-yellow-400",
+  4: "bg-yellow-400/25 border-yellow-300/50 text-yellow-300",
+};
+
+export function TraitBadge({ trait, lookup }: TraitBadgeProps) {
+  const traitData = lookup.traitByApiName.get(trait.apiName);
+  const color =
+    styleColors[trait.style] ??
+    "bg-lofi-surface border-lofi-border text-lofi-muted";
+
+  return (
+    <div
+      className={`flex items-center gap-1 rounded border px-1 py-0.5 ${color}`}
+      title={traitData?.name ?? trait.apiName}
+    >
+      {traitData?.iconUrl ? (
+        <img
+          src={traitData.iconUrl}
+          alt={traitData.name}
+          className="h-4 w-4"
+          loading="lazy"
+        />
+      ) : (
+        <span className="text-[9px] leading-none">
+          {formatTraitName(trait.apiName)}
+        </span>
+      )}
+      <span className="text-xs font-bold leading-none">{trait.numUnits}</span>
+    </div>
+  );
+}
+
+function formatTraitName(apiName: string): string {
+  return apiName.replace(/^Set\d+_/, "").replace(/TFT\d+_/, "");
+}

--- a/frontend/src/components/player/unit-icon.tsx
+++ b/frontend/src/components/player/unit-icon.tsx
@@ -1,0 +1,84 @@
+import type { PatchLookup } from "@/hooks/use-patch-lookup";
+import type { MatchUnit } from "@/gen/tft/v1/player_pb";
+
+interface UnitIconProps {
+  unit: MatchUnit;
+  lookup: PatchLookup;
+}
+
+const costBorderColors: Record<number, string> = {
+  1: "border-cost-1",
+  2: "border-cost-2",
+  3: "border-cost-3",
+  4: "border-cost-4",
+  5: "border-cost-5",
+};
+
+export function UnitIcon({ unit, lookup }: UnitIconProps) {
+  const champion = lookup.championByApiName.get(unit.characterId);
+  const cost = champion?.cost ?? unit.rarity + 1;
+  const borderColor = costBorderColors[cost] ?? "border-lofi-border";
+  const iconUrl = champion?.squareIconUrl;
+
+  return (
+    <div className="flex h-[62px] flex-col items-center gap-0.5">
+      {/* Champion icon */}
+      <div className="relative">
+        {iconUrl ? (
+          <img
+            src={iconUrl}
+            alt={champion?.name ?? unit.characterId}
+            className={`h-11 w-11 rounded border-2 ${borderColor} object-cover`}
+            loading="lazy"
+          />
+        ) : (
+          <div
+            className={`flex h-11 w-11 items-center justify-center rounded border-2 ${borderColor} bg-lofi-black text-[9px] text-lofi-muted`}
+          >
+            ?
+          </div>
+        )}
+
+        {/* Star overlay */}
+        {unit.tier >= 2 && (
+          <div className="absolute -top-2 left-1/2 -translate-x-1/2">
+            <span
+              className={`text-[9px] font-bold leading-none ${
+                unit.tier >= 3
+                  ? "text-yellow-300 drop-shadow-[0_0_4px_rgba(253,224,71,0.8)]"
+                  : "text-yellow-400 drop-shadow-[0_0_2px_rgba(250,204,21,0.5)]"
+              }`}
+            >
+              {"★".repeat(unit.tier)}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Item icons */}
+      {unit.itemNames.length > 0 && (
+        <div className="flex gap-0.5">
+          {unit.itemNames.slice(0, 3).map((itemName, i) => {
+            const item = lookup.itemByApiName.get(itemName);
+            return item?.iconUrl ? (
+              <img
+                key={i}
+                src={item.iconUrl}
+                alt={item.name}
+                title={item.name}
+                className="h-3.5 w-3.5 rounded-sm border border-lofi-border/50"
+                loading="lazy"
+              />
+            ) : (
+              <div
+                key={i}
+                className="h-3.5 w-3.5 rounded-sm bg-lofi-muted/50"
+                title={itemName}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/use-match-history.ts
+++ b/frontend/src/hooks/use-match-history.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { playerClient } from "@/lib/transport";
+
+export function useMatchHistory(
+  puuid: string,
+  region: string,
+  count = 20,
+) {
+  return useQuery({
+    queryKey: ["matchHistory", puuid, region, count],
+    queryFn: () => playerClient.getMatchHistory({ puuid, region, count }),
+    enabled: !!puuid,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+}

--- a/frontend/src/hooks/use-patch-data.ts
+++ b/frontend/src/hooks/use-patch-data.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { patchClient } from "../lib/transport";
+import { patchClient } from "@/lib/transport";
 
 export function usePatchData(setNumber = 0) {
   return useQuery({

--- a/frontend/src/hooks/use-patch-lookup.ts
+++ b/frontend/src/hooks/use-patch-lookup.ts
@@ -1,0 +1,40 @@
+import { useMemo } from "react";
+import { usePatchData } from "@/hooks/use-patch-data";
+import type { Champion, Item, Trait } from "@/gen/tft/v1/patch_pb";
+
+export interface PatchLookup {
+  championByApiName: Map<string, Champion>;
+  itemByApiName: Map<string, Item>;
+  traitByApiName: Map<string, Trait>;
+  isLoading: boolean;
+}
+
+export function usePatchLookup(): PatchLookup {
+  const { data, isLoading } = usePatchData();
+
+  const championByApiName = useMemo(() => {
+    const map = new Map<string, Champion>();
+    if (data?.champions) {
+      for (const c of data.champions) map.set(c.apiName, c);
+    }
+    return map;
+  }, [data?.champions]);
+
+  const itemByApiName = useMemo(() => {
+    const map = new Map<string, Item>();
+    if (data?.items) {
+      for (const i of data.items) map.set(i.apiName, i);
+    }
+    return map;
+  }, [data?.items]);
+
+  const traitByApiName = useMemo(() => {
+    const map = new Map<string, Trait>();
+    if (data?.traits) {
+      for (const t of data.traits) map.set(t.apiName, t);
+    }
+    return map;
+  }, [data?.traits]);
+
+  return { championByApiName, itemByApiName, traitByApiName, isLoading };
+}

--- a/frontend/src/hooks/use-player-profile.ts
+++ b/frontend/src/hooks/use-player-profile.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { playerClient } from "@/lib/transport";
+
+export function usePlayerProfile(
+  gameName: string,
+  tagLine: string,
+  region: string,
+) {
+  return useQuery({
+    queryKey: ["playerProfile", gameName, tagLine, region],
+    queryFn: () => playerClient.getPlayerProfile({ gameName, tagLine, region }),
+    enabled: !!gameName && !!tagLine,
+    staleTime: 10 * 60 * 1000,
+    retry: false,
+  });
+}

--- a/frontend/src/lib/transport.ts
+++ b/frontend/src/lib/transport.ts
@@ -1,9 +1,11 @@
 import { createClient } from "@connectrpc/connect";
 import { createConnectTransport } from "@connectrpc/connect-web";
 import { PatchService } from "../gen/tft/v1/patch_pb";
+import { PlayerService } from "../gen/tft/v1/player_pb";
 
 export const transport = createConnectTransport({
   baseUrl: "http://localhost:8080",
 });
 
 export const patchClient = createClient(PatchService, transport);
+export const playerClient = createClient(PlayerService, transport);

--- a/frontend/src/pages/champions.tsx
+++ b/frontend/src/pages/champions.tsx
@@ -1,9 +1,9 @@
 import { useState, useMemo } from "react";
-import { usePatchData } from "../hooks/use-patch-data";
-import { SectionHeader } from "../components/layout/section-header";
-import { SearchFilterBar } from "../components/search-filter-bar";
-import { ChampionCard } from "../components/champion-card";
-import { Skeleton } from "../components/ui/skeleton";
+import { usePatchData } from "@/hooks/use-patch-data";
+import { SectionHeader } from "@/components/layout/section-header";
+import { SearchFilterBar } from "@/components/search-filter-bar";
+import { ChampionCard } from "@/components/champion-card";
+import { Skeleton } from "@/components/ui/skeleton";
 
 const costFilters = [
   { label: "1g", value: "1" },

--- a/frontend/src/pages/items.tsx
+++ b/frontend/src/pages/items.tsx
@@ -1,9 +1,9 @@
 import { useState, useMemo } from "react";
-import { usePatchData } from "../hooks/use-patch-data";
-import { SectionHeader } from "../components/layout/section-header";
-import { SearchFilterBar } from "../components/search-filter-bar";
-import { ItemCard } from "../components/item-card";
-import { Skeleton } from "../components/ui/skeleton";
+import { usePatchData } from "@/hooks/use-patch-data";
+import { SectionHeader } from "@/components/layout/section-header";
+import { SearchFilterBar } from "@/components/search-filter-bar";
+import { ItemCard } from "@/components/item-card";
+import { Skeleton } from "@/components/ui/skeleton";
 
 const typeFilters = [
   { label: "component", value: "component" },

--- a/frontend/src/pages/player.tsx
+++ b/frontend/src/pages/player.tsx
@@ -1,0 +1,112 @@
+import { useEffect } from "react";
+import { usePlayerProfile } from "@/hooks/use-player-profile";
+import { useMatchHistory } from "@/hooks/use-match-history";
+import { usePatchLookup } from "@/hooks/use-patch-lookup";
+import { usePlayerStore } from "@/stores/player-store";
+import { SectionHeader } from "@/components/layout/section-header";
+import { RiotIdForm } from "@/components/player/riot-id-form";
+import { ProfileHeader } from "@/components/player/profile-header";
+import { MatchCard } from "@/components/player/match-card";
+import { AnalyticsPanel } from "@/components/player/analytics-panel";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function PlayerPage() {
+  const { gameName, tagLine, region, puuid, setSearch, setPUUID } =
+    usePlayerStore();
+
+  const profile = usePlayerProfile(gameName, tagLine, region);
+  const matchHistory = useMatchHistory(puuid, region);
+  const patchLookup = usePatchLookup();
+
+  useEffect(() => {
+    if (profile.data?.account?.puuid) {
+      setPUUID(profile.data.account.puuid);
+    }
+  }, [profile.data?.account?.puuid, setPUUID]);
+
+  const handleSearch = (gn: string, tl: string, r: string) => {
+    setSearch(gn, tl, r);
+  };
+
+  return (
+    <div>
+      <SectionHeader number="03" title="player" />
+
+      <div className="mb-4">
+        <RiotIdForm onSubmit={handleSearch} isLoading={profile.isLoading} />
+      </div>
+
+      {profile.error && (
+        <div className="mb-4 rounded-sm border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+          {profile.error.message}
+        </div>
+      )}
+
+      {profile.isLoading && (
+        <div className="space-y-3">
+          <Skeleton className="h-20" />
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+            <Skeleton className="h-48" />
+            <Skeleton className="h-48" />
+            <Skeleton className="h-48" />
+          </div>
+        </div>
+      )}
+
+      {profile.data?.account && (
+        <div className="space-y-4">
+          <ProfileHeader
+            account={profile.data.account}
+            summoner={profile.data.summoner}
+            rankedEntries={profile.data.rankedEntries}
+          />
+
+          {matchHistory.data?.matches &&
+            matchHistory.data.matches.length > 0 && (
+              <>
+                <SectionHeader number="03.1" title="analytics" />
+                <AnalyticsPanel
+                  matches={matchHistory.data.matches}
+                  puuid={puuid}
+                />
+              </>
+            )}
+
+          <SectionHeader number="03.2" title="match history" />
+
+          {matchHistory.isLoading && (
+            <div className="space-y-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-20" />
+              ))}
+            </div>
+          )}
+
+          {matchHistory.error && (
+            <div className="rounded-sm border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+              {matchHistory.error.message}
+            </div>
+          )}
+
+          {matchHistory.data?.matches && (
+            <>
+              <p className="mb-2 text-xs text-lofi-muted">
+                {matchHistory.data.matches.length} matches
+              </p>
+              <div className="space-y-2">
+                {matchHistory.data.matches.map((match) => (
+                  <MatchCard
+                    key={match.metadata?.matchId}
+                    match={match}
+                    playerPuuid={puuid}
+                    patchLookup={patchLookup}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/stores/player-store.ts
+++ b/frontend/src/stores/player-store.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+
+interface PlayerState {
+  gameName: string;
+  tagLine: string;
+  region: string;
+  puuid: string;
+  setSearch: (gameName: string, tagLine: string, region: string) => void;
+  setPUUID: (puuid: string) => void;
+  clear: () => void;
+}
+
+export const usePlayerStore = create<PlayerState>((set) => ({
+  gameName: "",
+  tagLine: "",
+  region: "br",
+  puuid: "",
+  setSearch: (gameName, tagLine, region) => set({ gameName, tagLine, region }),
+  setPUUID: (puuid) => set({ puuid }),
+  clear: () => set({ gameName: "", tagLine: "", region: "americas", puuid: "" }),
+}));

--- a/insomnia.json
+++ b/insomnia.json
@@ -73,7 +73,7 @@
       "_id": "req_get_player_profile",
       "_type": "request",
       "parentId": "fld_player",
-      "name": "GetPlayerProfile (unimplemented)",
+      "name": "GetPlayerProfile",
       "method": "POST",
       "url": "{{ _.base_url }}/tft.v1.PlayerService/GetPlayerProfile",
       "headers": [
@@ -81,14 +81,14 @@
       ],
       "body": {
         "mimeType": "application/json",
-        "text": "{\n  \"gameName\": \"MeninoNias\",\n  \"tagLine\": \"BR1\",\n  \"region\": \"americas\"\n}"
+        "text": "{\n  \"gameName\": \"pai de olivia\",\n  \"tagLine\": \"NIAS\",\n  \"region\": \"br\"\n}"
       }
     },
     {
       "_id": "req_get_match_history",
       "_type": "request",
       "parentId": "fld_player",
-      "name": "GetMatchHistory (unimplemented)",
+      "name": "GetMatchHistory",
       "method": "POST",
       "url": "{{ _.base_url }}/tft.v1.PlayerService/GetMatchHistory",
       "headers": [
@@ -96,7 +96,7 @@
       ],
       "body": {
         "mimeType": "application/json",
-        "text": "{\n  \"puuid\": \"some-puuid\",\n  \"region\": \"americas\",\n  \"count\": 20\n}"
+        "text": "{\n  \"puuid\": \"gAI2DzIlT48o_0ebAl5epBUqxikAjDxNOJx9VB9GScjzgWACEdxX3wD1qhTX9IpOb6i5IEChRMgofw\",\n  \"region\": \"br\",\n  \"count\": 5\n}"
       }
     }
   ]

--- a/migrations/000006_create_players.down.sql
+++ b/migrations/000006_create_players.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS players;

--- a/migrations/000006_create_players.up.sql
+++ b/migrations/000006_create_players.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE players (
+    puuid           TEXT PRIMARY KEY,
+    game_name       TEXT NOT NULL DEFAULT '',
+    tag_line        TEXT NOT NULL DEFAULT '',
+    region          TEXT NOT NULL DEFAULT '',
+    platform        TEXT NOT NULL DEFAULT '',
+    summoner_id     TEXT NOT NULL DEFAULT '',
+    profile_icon_id INT NOT NULL DEFAULT 0,
+    summoner_level  BIGINT NOT NULL DEFAULT 0,
+    tier            TEXT NOT NULL DEFAULT '',
+    rank            TEXT NOT NULL DEFAULT '',
+    league_points   INT NOT NULL DEFAULT 0,
+    wins            INT NOT NULL DEFAULT 0,
+    losses          INT NOT NULL DEFAULT 0,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_players_riot_id ON players(game_name, tag_line);

--- a/migrations/000007_create_matches.down.sql
+++ b/migrations/000007_create_matches.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS matches;

--- a/migrations/000007_create_matches.up.sql
+++ b/migrations/000007_create_matches.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE matches (
+    match_id            TEXT PRIMARY KEY,
+    data_version        TEXT NOT NULL DEFAULT '',
+    game_datetime       BIGINT NOT NULL DEFAULT 0,
+    game_length         REAL NOT NULL DEFAULT 0,
+    game_version        TEXT NOT NULL DEFAULT '',
+    queue_id            INT NOT NULL DEFAULT 0,
+    tft_set_number      INT NOT NULL DEFAULT 0,
+    tft_game_type       TEXT NOT NULL DEFAULT '',
+    participant_puuids  TEXT[] NOT NULL DEFAULT '{}',
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_matches_game_datetime ON matches(game_datetime DESC);

--- a/migrations/000008_create_match_participants.down.sql
+++ b/migrations/000008_create_match_participants.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS match_participants;

--- a/migrations/000008_create_match_participants.up.sql
+++ b/migrations/000008_create_match_participants.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE match_participants (
+    match_id                TEXT NOT NULL REFERENCES matches(match_id) ON DELETE CASCADE,
+    puuid                   TEXT NOT NULL,
+    placement               INT NOT NULL DEFAULT 0,
+    level                   INT NOT NULL DEFAULT 0,
+    gold_left               INT NOT NULL DEFAULT 0,
+    last_round              INT NOT NULL DEFAULT 0,
+    time_eliminated         REAL NOT NULL DEFAULT 0,
+    total_damage_to_players INT NOT NULL DEFAULT 0,
+    players_eliminated      INT NOT NULL DEFAULT 0,
+    augments                TEXT[] NOT NULL DEFAULT '{}',
+    companion               JSONB NOT NULL DEFAULT '{}',
+    traits                  JSONB NOT NULL DEFAULT '[]',
+    units                   JSONB NOT NULL DEFAULT '[]',
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (match_id, puuid)
+);
+
+CREATE INDEX idx_match_participants_puuid ON match_participants(puuid);


### PR DESCRIPTION
## Overview

Phase 2 adds **player analytics**: Riot API integration, match history persistence, player dashboard UI, analytics module, and Redis caching.

Closes #7, Closes #8, Closes #9, Closes #10, Closes #11

---

## Implementation Plan

### 1. Config & Infrastructure (#11)
- [x] Add `RIOT_API_KEY`, `REDIS_URL` to `backend/internal/config/config.go`
- [x] Create `backend/internal/cache/redis.go` — Redis client with graceful degradation
- [x] Integrate Redis into `cmd/server/main.go` startup (optional, logs warning on failure)

### 2. Riot API Client (#7)
- [x] Create `backend/internal/riot/client.go` — HTTP client with:
  - Account V1: `GET /riot/account/v1/accounts/by-riot-id/{gameName}/{tagLine}`
  - Summoner V1: `GET /tft/summoner/v1/summoners/by-puuid/{puuid}`
  - League V1: `GET /tft/league/v1/by-puuid/{puuid}`
  - Match V1 (list): `GET /tft/match/v1/matches/by-puuid/{puuid}/ids`
  - Match V1 (detail): `GET /tft/match/v1/matches/{matchId}`
- [x] Rate limiting (20 req/s dev key via `golang.org/x/time/rate`)
- [ ] Retry with exponential backoff for 429/5xx
- [x] Error mapping (404 → NotFound, 403 → PermissionDenied, 429 → ResourceExhausted)
- [x] URL encoding for game names with spaces (e.g. "pai de olivia")
- [x] Health check on startup to validate API key
- [x] `routing.go` — ResolveServer() maps server codes (br, na, euw) to region + platform
- [ ] Tests for client error handling

### 3. Database Schema (#8)
- [x] `000006_create_players.up.sql` — denormalized player + ranked data (puuid PK, game_name, tag_line, region, tier, rank, lp, wins, losses)
- [x] `000007_create_matches.up.sql` — match metadata (match_id PK, game_datetime, game_length, participant_puuids array)
- [x] `000008_create_match_participants.up.sql` — per-player match data (match_id+puuid PK, placement, traits/units/companion as JSONB)
- [x] sqlc queries: `players.sql`, `matches.sql`, `match_participants.sql`
- [x] `DeleteChampionsBySet` and `DeleteItemsBySet` queries for clean re-sync

### 4. Player Service Implementation (#7, #8)
- [x] Implement `GetPlayerProfile` in `backend/internal/player/service.go`:
  - Riot ID → Account API → PUUID (with Redis cache, 24h TTL)
  - PUUID → Summoner API + League API in parallel
  - Persist to PostgreSQL, cache in Redis (10min), return proto response
- [x] Implement `GetMatchHistory`:
  - PUUID → Match list API → match IDs
  - For each match: Redis cache → DB → Riot API (fallback chain)
  - Persist new matches in DB transaction, return proto response
- [x] Redis caching:
  - PUUID resolution: TTL 24h
  - Match list: TTL 5min (invalidates when cached count < requested count)
  - Match detail: permanent (matches are immutable)
  - Player profile: TTL 10min
- [x] `mapper.go` — DTO↔Proto↔JSONB conversions for all data types

### 5. Frontend — Player Dashboard (#9)
- [x] Create `playerClient` in `frontend/src/lib/transport.ts`
- [x] Create `frontend/src/stores/player-store.ts` — Zustand store (gameName, tagLine, region, puuid)
- [x] Create hooks:
  - `use-player-profile.ts` — TanStack Query for GetPlayerProfile
  - `use-match-history.ts` — TanStack Query for GetMatchHistory
  - `use-patch-lookup.ts` — builds Map<apiName, T> for icon resolution
- [x] Create player page (`pages/player.tsx`) combining:
  - Riot ID search form with server selector (BR, NA, EUW, KR, etc.)
  - Profile header with rank badge, LP, win/loss
  - Analytics panel
  - Match history list
- [x] Create components:
  - `riot-id-form.tsx` — gameName + tagLine + server selector
  - `profile-header.tsx` — TerminalCard with tier colors
  - `match-card.tsx` — champion icons with cost borders, star overlays, item icons, trait badges, expandable detail
  - `match-detail.tsx` — all 8 participants with icons in expanded view
  - `unit-icon.tsx` — champion square with cost-colored border, star overlay, item icons below
  - `trait-badge.tsx` — trait icon with bronze/silver/gold/chromatic styling
  - `placement-badge.tsx` — color-coded placement with sm/md sizes
  - `analytics-panel.tsx` — placement distribution, top traits/champions stats
- [x] Update `App.tsx` routes: add `/player`
- [x] Update sidebar navigation + version to `v0.2.0 // phase 2`
- [x] Migrate all imports to `@/` alias

### 6. Analytics Module (#10)
- [x] Client-side analytics computed from match data (no new RPC needed for MVP):
  - Average placement, top 4 rate, win rate
  - Placement distribution histogram with styled bars
  - Top traits by games played with avg placement and top4%
  - Top champions by games played with avg placement
- [ ] Backend-side `GetPlayerAnalytics` RPC (deferred — client-side is sufficient for MVP)

### 7. Data Quality Fixes
- [x] CommunityDragon sync now deletes stale champions/items before re-inserting
- [x] Item filter tightened: excludes Grant*, Debug*, Free*, Blank, Copy, Piltover/Bilgewater mechanics, unlocalized names

---

## Architecture

```
Frontend (React)                    Backend (Go)                     External
┌─────────────┐                    ┌──────────────┐                ┌──────────┐
│ PlayerSearch │──Connect RPC──►   │ PlayerService│──HTTP──►       │ Riot API │
│ MatchHistory │                   │  GetProfile  │                │ Account  │
│ Analytics    │                   │  GetMatches  │                │ Summoner │
└─────────────┘                   └──────┬───────┘                │ League   │
                                          │                        │ Match    │
                                   ┌──────▼───────┐                └──────────┘
                                   │  PostgreSQL   │  ← persist players, matches
                                   │  Redis        │  ← cache API responses
                                   └──────────────┘
```

## Key Decisions
- **Riot API key stays server-side only** — frontend never sees it
- **Match data is immutable** — once fetched, cache permanently in Redis + PostgreSQL
- **Top 4 = "win"** — standard TFT metric for analytics
- **`apiName` remains the universal join key** — links match units/traits back to CommunityDragon data
- **Server selector instead of region** — maps BR/NA/EUW to both regional (Account, Match) and platform (Summoner, League) routing
- **Client-side analytics for MVP** — avoids new RPC, computes from already-fetched match data

## Test Plan
- [ ] Riot API client: unit tests with mocked HTTP responses (success, 404, 429, 5xx)
- [ ] Player service: integration tests with test database
- [x] sqlc queries: generated and verified with `sqlc generate`
- [ ] Redis caching: test TTL expiry and cache hit/miss
- [ ] Frontend hooks: verify loading/error/success states
- [x] E2E: search player → view profile → browse match history → see analytics
- [x] Item/champion filter: 28 parser tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)