### PR TITLE
feat: user authentication with access key + Riot ID linking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@ SERVER_PORT=8080
 SERVER_HOST=localhost
 
 # ========================
+# Auth (JWT)
+# ========================
+JWT_SECRET=your-secret-key-change-this-in-production
+JWT_EXPIRY=720h
+
+# ========================
 # Environment
 # ========================
 APP_ENV=development

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/net/http2/h2c"
 
 	"github.com/MeninoNias/tft-oracle/backend/gen/tft/v1/tftv1connect"
+	"github.com/MeninoNias/tft-oracle/backend/internal/auth"
 	"github.com/MeninoNias/tft-oracle/backend/internal/cache"
 	"github.com/MeninoNias/tft-oracle/backend/internal/cdragon"
 	"github.com/MeninoNias/tft-oracle/backend/internal/config"
@@ -98,10 +99,26 @@ func main() {
 		log.Println("riot api: not configured (player features disabled)")
 	}
 
+	// Auth (optional — works without JWT_SECRET, but auth endpoints return errors)
+	var jwtMgr *auth.JWTManager
+	if cfg.JWTSecret != "" {
+		var err error
+		jwtMgr, err = auth.NewJWTManager(cfg.JWTSecret, cfg.JWTExpiry)
+		if err != nil {
+			log.Fatalf("failed to init JWT: %v", err)
+		}
+		log.Println("auth: JWT configured")
+	} else {
+		log.Println("auth: JWT_SECRET not set — auth features disabled")
+	}
+
 	// Set up Connect RPC handlers
 	mux := http.NewServeMux()
 
-	interceptors := connect.WithInterceptors(newLoggingInterceptor())
+	interceptors := connect.WithInterceptors(
+		auth.NewAuthInterceptor(jwtMgr),
+		newLoggingInterceptor(),
+	)
 
 	patchPath, patchHandler := tftv1connect.NewPatchServiceHandler(
 		patch.NewService(pool),
@@ -114,6 +131,12 @@ func main() {
 		interceptors,
 	)
 	mux.Handle(playerPath, playerHandler)
+
+	authPath, authHandler := tftv1connect.NewAuthServiceHandler(
+		auth.NewService(pool, riotClient, jwtMgr),
+		interceptors,
+	)
+	mux.Handle(authPath, authHandler)
 
 	// CORS configuration
 	corsHandler := cors.New(cors.Options{
@@ -128,6 +151,7 @@ func main() {
 			http.MethodOptions,
 		},
 		AllowedHeaders: []string{
+			"Authorization",
 			"Content-Type",
 			"Connect-Protocol-Version",
 			"Connect-Timeout-Ms",

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -15,12 +15,14 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/redis/go-redis/v9 v9.18.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -33,6 +33,8 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang-migrate/migrate/v4 v4.19.1 h1:OCyb44lFuQfYXYLx1SCxPZQGU7mcaZ7gH9yH4jSFbBA=
 github.com/golang-migrate/migrate/v4 v4.19.1/go.mod h1:CTcgfjxhaUtsLipnLoQRWCrjYXycRz/g5+RWDuYgPrE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -85,6 +87,8 @@ go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mx
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
+golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
+golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
 golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -1,0 +1,78 @@
+package auth
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type Claims struct {
+	UserID string `json:"user_id"`
+	PUUID  string `json:"puuid"`
+	jwt.RegisteredClaims
+}
+
+type JWTManager struct {
+	secret []byte
+	expiry time.Duration
+}
+
+func NewJWTManager(secret string, expiryStr string) (*JWTManager, error) {
+	if secret == "" {
+		return nil, fmt.Errorf("JWT_SECRET is required for auth")
+	}
+
+	expiry, err := time.ParseDuration(expiryStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid JWT_EXPIRY %q: %w", expiryStr, err)
+	}
+
+	return &JWTManager{
+		secret: []byte(secret),
+		expiry: expiry,
+	}, nil
+}
+
+func (m *JWTManager) Generate(userID pgtype.UUID, puuid string) (string, error) {
+	claims := Claims{
+		UserID: uuidToString(userID),
+		PUUID:  puuid,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(m.expiry)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Issuer:    "tft-oracle",
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(m.secret)
+}
+
+func (m *JWTManager) Validate(tokenStr string) (*Claims, error) {
+	token, err := jwt.ParseWithClaims(tokenStr, &Claims{}, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return m.secret, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("invalid token: %w", err)
+	}
+
+	claims, ok := token.Claims.(*Claims)
+	if !ok || !token.Valid {
+		return nil, fmt.Errorf("invalid token claims")
+	}
+
+	return claims, nil
+}
+
+func uuidToString(u pgtype.UUID) string {
+	if !u.Valid {
+		return ""
+	}
+	b := u.Bytes
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -1,0 +1,61 @@
+package auth
+
+import (
+	"context"
+	"strings"
+
+	"connectrpc.com/connect"
+)
+
+type contextKey string
+
+const userContextKey contextKey = "auth_user"
+
+// UserFromContext extracts the authenticated user claims from the context.
+// Returns nil if no user is authenticated.
+func UserFromContext(ctx context.Context) *Claims {
+	claims, _ := ctx.Value(userContextKey).(*Claims)
+	return claims
+}
+
+// NewAuthInterceptor creates a Connect RPC interceptor that validates JWT tokens.
+// It extracts the token from the Authorization header (Bearer scheme).
+// Unauthenticated requests pass through — individual handlers decide if auth is required.
+func NewAuthInterceptor(jwtMgr *JWTManager) connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			if jwtMgr == nil {
+				return next(ctx, req)
+			}
+
+			authHeader := req.Header().Get("Authorization")
+			if authHeader == "" {
+				return next(ctx, req)
+			}
+
+			token := strings.TrimPrefix(authHeader, "Bearer ")
+			if token == authHeader {
+				// No "Bearer " prefix — skip
+				return next(ctx, req)
+			}
+
+			claims, err := jwtMgr.Validate(token)
+			if err != nil {
+				return nil, connect.NewError(connect.CodeUnauthenticated, err)
+			}
+
+			ctx = context.WithValue(ctx, userContextKey, claims)
+			return next(ctx, req)
+		}
+	}
+}
+
+// RequireAuth is a helper that checks if the request is authenticated.
+// Call this at the start of handlers that require authentication.
+func RequireAuth(ctx context.Context) (*Claims, error) {
+	claims := UserFromContext(ctx)
+	if claims == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, nil)
+	}
+	return claims, nil
+}

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -1,0 +1,200 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"log"
+
+	"connectrpc.com/connect"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/crypto/bcrypt"
+
+	tftv1 "github.com/MeninoNias/tft-oracle/backend/gen/tft/v1"
+	"github.com/MeninoNias/tft-oracle/backend/gen/tft/v1/tftv1connect"
+	"github.com/MeninoNias/tft-oracle/backend/internal/riot"
+	"github.com/MeninoNias/tft-oracle/backend/sqlc/generated"
+)
+
+var _ tftv1connect.AuthServiceHandler = (*Service)(nil)
+
+type Service struct {
+	db      *pgxpool.Pool
+	queries *generated.Queries
+	riot    *riot.Client
+	jwt     *JWTManager
+}
+
+func NewService(db *pgxpool.Pool, riotClient *riot.Client, jwtMgr *JWTManager) *Service {
+	return &Service{
+		db:      db,
+		queries: generated.New(db),
+		riot:    riotClient,
+		jwt:     jwtMgr,
+	}
+}
+
+func (s *Service) Register(
+	ctx context.Context,
+	req *connect.Request[tftv1.RegisterRequest],
+) (*connect.Response[tftv1.RegisterResponse], error) {
+	gameName := req.Msg.GetGameName()
+	tagLine := req.Msg.GetTagLine()
+	region := req.Msg.GetRegion()
+
+	if gameName == "" || tagLine == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("game_name and tag_line are required"))
+	}
+	if region == "" {
+		region = "br"
+	}
+
+	if !s.riot.Available() {
+		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("Riot API not configured"))
+	}
+
+	// 1. Verify Riot ID exists
+	server := riot.ResolveServer(region)
+	account, err := s.riot.GetAccountByRiotID(ctx, server.Region, gameName, tagLine)
+	if err != nil {
+		return nil, fmt.Errorf("verify riot id: %w", err)
+	}
+
+	// 2. Check if user already exists with this PUUID
+	existing, err := s.queries.GetUserByPUUID(ctx, account.PUUID)
+	if err == nil {
+		return nil, connect.NewError(connect.CodeAlreadyExists,
+			fmt.Errorf("account %s#%s is already registered (user %s)", existing.GameName, existing.TagLine, uuidToString(existing.ID)))
+	}
+
+	// 3. Generate access key (32 bytes → base64url, ~43 chars)
+	rawKey, err := generateAccessKey()
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("generate key: %w", err))
+	}
+
+	// 4. Hash the key with bcrypt
+	hash, err := bcrypt.GenerateFromPassword([]byte(rawKey), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("hash key: %w", err))
+	}
+
+	// 5. Create user in DB
+	user, err := s.queries.CreateUser(ctx, generated.CreateUserParams{
+		AccessKeyHash: string(hash),
+		RiotPuuid:     account.PUUID,
+		GameName:      gameName,
+		TagLine:       tagLine,
+		Region:        region,
+	})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create user: %w", err))
+	}
+
+	log.Printf("auth: registered user %s (%s#%s)", uuidToString(user.ID), gameName, tagLine)
+
+	return connect.NewResponse(&tftv1.RegisterResponse{
+		AccessKey: rawKey,
+		User:      mapUserToProto(user),
+	}), nil
+}
+
+func (s *Service) Login(
+	ctx context.Context,
+	req *connect.Request[tftv1.LoginRequest],
+) (*connect.Response[tftv1.LoginResponse], error) {
+	accessKey := req.Msg.GetAccessKey()
+	if accessKey == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("access_key is required"))
+	}
+
+	// Find all users and check bcrypt (no way to query by bcrypt hash directly)
+	// For a small user base this is fine. For scale, store a key prefix for lookup.
+	user, err := s.findUserByAccessKey(ctx, accessKey)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("invalid access key"))
+	}
+
+	// Generate JWT
+	token, err := s.jwt.Generate(user.ID, user.RiotPuuid)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("generate token: %w", err))
+	}
+
+	// Update last seen
+	_ = s.queries.UpdateLastSeen(ctx, user.ID)
+
+	log.Printf("auth: login user %s (%s#%s)", uuidToString(user.ID), user.GameName, user.TagLine)
+
+	return connect.NewResponse(&tftv1.LoginResponse{
+		SessionToken: token,
+		User:         mapUserToProto(user),
+	}), nil
+}
+
+func (s *Service) GetCurrentUser(
+	ctx context.Context,
+	req *connect.Request[tftv1.GetCurrentUserRequest],
+) (*connect.Response[tftv1.GetCurrentUserResponse], error) {
+	claims, err := RequireAuth(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var userID pgtype.UUID
+	if err := userID.Scan(claims.UserID); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("invalid user id in token"))
+	}
+
+	user, err := s.queries.GetUserByID(ctx, userID)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("user not found"))
+	}
+
+	return connect.NewResponse(&tftv1.GetCurrentUserResponse{
+		User: mapUserToProto(user),
+	}), nil
+}
+
+// findUserByAccessKey scans users to find one matching the bcrypt hash.
+// For a small-scale desktop app this is acceptable. For production scale,
+// store a non-reversible key prefix (first 8 chars of SHA-256) for indexed lookup.
+func (s *Service) findUserByAccessKey(ctx context.Context, accessKey string) (generated.User, error) {
+	rows, err := s.db.Query(ctx, "SELECT id, access_key_hash, riot_puuid, game_name, tag_line, region, created_at, last_seen FROM users")
+	if err != nil {
+		return generated.User{}, fmt.Errorf("query users: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var u generated.User
+		if err := rows.Scan(&u.ID, &u.AccessKeyHash, &u.RiotPuuid, &u.GameName, &u.TagLine, &u.Region, &u.CreatedAt, &u.LastSeen); err != nil {
+			continue
+		}
+		if bcrypt.CompareHashAndPassword([]byte(u.AccessKeyHash), []byte(accessKey)) == nil {
+			return u, nil
+		}
+	}
+
+	return generated.User{}, fmt.Errorf("no matching user")
+}
+
+func generateAccessKey() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(b), nil
+}
+
+func mapUserToProto(u generated.User) *tftv1.User {
+	return &tftv1.User{
+		Id:       uuidToString(u.ID),
+		GameName: u.GameName,
+		TagLine:  u.TagLine,
+		Region:   u.Region,
+		Puuid:    u.RiotPuuid,
+	}
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -15,6 +15,10 @@ type Config struct {
 	// Phase 2: Riot API & Redis
 	RiotAPIKey string
 	RedisURL   string
+
+	// Auth
+	JWTSecret string
+	JWTExpiry string // duration string, e.g. "720h" for 30 days
 }
 
 func Load() (*Config, error) {
@@ -26,6 +30,8 @@ func Load() (*Config, error) {
 		LogLevel:    getEnv("LOG_LEVEL", "debug"),
 		RiotAPIKey:  getEnv("RIOT_API_KEY", ""),
 		RedisURL:    getEnv("REDIS_URL", "redis://localhost:6379"),
+		JWTSecret:   getEnv("JWT_SECRET", ""),
+		JWTExpiry:   getEnv("JWT_EXPIRY", "720h"),
 	}
 
 	if cfg.DatabaseURL == "" {

--- a/backend/sqlc/queries/users.sql
+++ b/backend/sqlc/queries/users.sql
@@ -1,0 +1,16 @@
+-- name: CreateUser :one
+INSERT INTO users (access_key_hash, riot_puuid, game_name, tag_line, region)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING *;
+
+-- name: GetUserByID :one
+SELECT * FROM users WHERE id = $1;
+
+-- name: GetUserByPUUID :one
+SELECT * FROM users WHERE riot_puuid = $1;
+
+-- name: GetUserByAccessKeyHash :one
+SELECT * FROM users WHERE access_key_hash = $1;
+
+-- name: UpdateLastSeen :exec
+UPDATE users SET last_seen = NOW() WHERE id = $1;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,9 @@
 import { Routes, Route, Navigate } from "react-router-dom";
-import { MainLayout } from "./components/layout/main-layout";
-import { ChampionsPage } from "./pages/champions";
-import { ItemsPage } from "./pages/items";
-import { PlayerPage } from "./pages/player";
+import { MainLayout } from "@/components/layout/main-layout";
+import { ChampionsPage } from "@/pages/champions";
+import { ItemsPage } from "@/pages/items";
+import { PlayerPage } from "@/pages/player";
+import { AuthPage } from "@/pages/auth";
 
 export function App() {
   return (
@@ -12,6 +13,7 @@ export function App() {
         <Route path="/champions" element={<ChampionsPage />} />
         <Route path="/items" element={<ItemsPage />} />
         <Route path="/player" element={<PlayerPage />} />
+        <Route path="/auth" element={<AuthPage />} />
       </Routes>
     </MainLayout>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from "react-router-dom";
 import { MainLayout } from "@/components/layout/main-layout";
 import { ChampionsPage } from "@/pages/champions";
 import { ItemsPage } from "@/pages/items";
+import { ProfilePage } from "@/pages/profile";
 import { PlayerPage } from "@/pages/player";
 import { AuthPage } from "@/pages/auth";
 
@@ -20,6 +21,7 @@ export function App() {
               <Route path="/" element={<Navigate to="/champions" replace />} />
               <Route path="/champions" element={<ChampionsPage />} />
               <Route path="/items" element={<ItemsPage />} />
+              <Route path="/profile" element={<ProfilePage />} />
               <Route path="/player" element={<PlayerPage />} />
             </Routes>
           </MainLayout>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,14 +7,24 @@ import { AuthPage } from "@/pages/auth";
 
 export function App() {
   return (
-    <MainLayout>
-      <Routes>
-        <Route path="/" element={<Navigate to="/champions" replace />} />
-        <Route path="/champions" element={<ChampionsPage />} />
-        <Route path="/items" element={<ItemsPage />} />
-        <Route path="/player" element={<PlayerPage />} />
-        <Route path="/auth" element={<AuthPage />} />
-      </Routes>
-    </MainLayout>
+    <Routes>
+      {/* Auth page — full-screen, no sidebar */}
+      <Route path="/auth" element={<AuthPage />} />
+
+      {/* App pages — with sidebar layout */}
+      <Route
+        path="*"
+        element={
+          <MainLayout>
+            <Routes>
+              <Route path="/" element={<Navigate to="/champions" replace />} />
+              <Route path="/champions" element={<ChampionsPage />} />
+              <Route path="/items" element={<ItemsPage />} />
+              <Route path="/player" element={<PlayerPage />} />
+            </Routes>
+          </MainLayout>
+        }
+      />
+    </Routes>
   );
 }

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -1,4 +1,5 @@
 import { NavLink } from "react-router-dom";
+import { useAuthStore } from "@/stores/auth-store";
 
 const navItems = [
   { to: "/champions", label: "champions" },
@@ -7,13 +8,18 @@ const navItems = [
 ];
 
 export function Sidebar() {
+  const { token, user, logout } = useAuthStore();
+  const isLoggedIn = !!token;
+
   return (
     <aside className="flex h-screen w-64 flex-col border-r border-lofi-border bg-lofi-black">
       <div className="border-b border-lofi-border px-4 py-4">
         <h1 className="text-sm font-bold tracking-wider text-white">
           TFT_ORACLE
         </h1>
-        <p className="mt-0.5 text-[10px] text-lofi-muted">v0.2.0 // phase 2</p>
+        <p className="mt-0.5 text-[10px] text-lofi-muted">
+          v0.2.0 // phase 2
+        </p>
       </div>
 
       <nav className="flex-1 px-2 py-3">
@@ -42,6 +48,30 @@ export function Sidebar() {
           </NavLink>
         ))}
       </nav>
+
+      <div className="border-t border-lofi-border px-4 py-3">
+        {isLoggedIn && user ? (
+          <div className="space-y-1">
+            <p className="text-xs text-lofi-text">
+              {user.gameName}
+              <span className="text-lofi-muted">#{user.tagLine}</span>
+            </p>
+            <button
+              onClick={logout}
+              className="text-[10px] text-lofi-muted hover:text-red-400"
+            >
+              logout
+            </button>
+          </div>
+        ) : (
+          <NavLink
+            to="/auth"
+            className="text-[10px] text-lofi-accent hover:text-lofi-text"
+          >
+            login / register
+          </NavLink>
+        )}
+      </div>
 
       <div className="border-t border-lofi-border px-4 py-3">
         <p className="text-[10px] text-lofi-muted">

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -4,7 +4,8 @@ import { useAuthStore } from "@/stores/auth-store";
 const navItems = [
   { to: "/champions", label: "champions" },
   { to: "/items", label: "items" },
-  { to: "/player", label: "profile" },
+  { to: "/profile", label: "profile" },
+  { to: "/player", label: "player search" },
 ];
 
 export function Sidebar() {

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -4,7 +4,7 @@ import { useAuthStore } from "@/stores/auth-store";
 const navItems = [
   { to: "/champions", label: "champions" },
   { to: "/items", label: "items" },
-  { to: "/player", label: "player" },
+  { to: "/player", label: "profile" },
 ];
 
 export function Sidebar() {

--- a/frontend/src/components/player/player-data.tsx
+++ b/frontend/src/components/player/player-data.tsx
@@ -1,0 +1,113 @@
+import { SectionHeader } from "@/components/layout/section-header";
+import { ProfileHeader } from "@/components/player/profile-header";
+import { MatchCard } from "@/components/player/match-card";
+import { AnalyticsPanel } from "@/components/player/analytics-panel";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { PatchLookup } from "@/hooks/use-patch-lookup";
+import type { GetPlayerProfileResponse } from "@/gen/tft/v1/player_pb";
+import type { GetMatchHistoryResponse } from "@/gen/tft/v1/player_pb";
+
+interface PlayerDataProps {
+  profile: {
+    data?: GetPlayerProfileResponse;
+    isLoading: boolean;
+    error: Error | null;
+  };
+  matchHistory: {
+    data?: GetMatchHistoryResponse;
+    isLoading: boolean;
+    error: Error | null;
+  };
+  puuid: string;
+  patchLookup: PatchLookup;
+  sectionPrefix?: string;
+}
+
+export function PlayerData({
+  profile,
+  matchHistory,
+  puuid,
+  patchLookup,
+  sectionPrefix = "03",
+}: PlayerDataProps) {
+  if (profile.error) {
+    return (
+      <div className="rounded-sm border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+        {profile.error.message}
+      </div>
+    );
+  }
+
+  if (profile.isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-20" />
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+          <Skeleton className="h-48" />
+          <Skeleton className="h-48" />
+          <Skeleton className="h-48" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!profile.data?.account) return null;
+
+  return (
+    <div className="space-y-4">
+      <ProfileHeader
+        account={profile.data.account}
+        summoner={profile.data.summoner}
+        rankedEntries={profile.data.rankedEntries}
+      />
+
+      {matchHistory.data?.matches &&
+        matchHistory.data.matches.length > 0 && (
+          <>
+            <SectionHeader
+              number={`${sectionPrefix}.1`}
+              title="analytics"
+            />
+            <AnalyticsPanel
+              matches={matchHistory.data.matches}
+              puuid={puuid}
+            />
+          </>
+        )}
+
+      <SectionHeader number={`${sectionPrefix}.2`} title="match history" />
+
+      {matchHistory.isLoading && (
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-20" />
+          ))}
+        </div>
+      )}
+
+      {matchHistory.error && (
+        <div className="rounded-sm border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+          {matchHistory.error.message}
+        </div>
+      )}
+
+      {matchHistory.data?.matches && (
+        <>
+          <p className="mb-2 text-xs text-lofi-muted">
+            {matchHistory.data.matches.length} matches
+          </p>
+          <div className="space-y-2">
+            {matchHistory.data.matches.map((match) => (
+              <MatchCard
+                key={match.metadata?.matchId}
+                match={match}
+                playerPuuid={puuid}
+                patchLookup={patchLookup}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { authClient } from "@/lib/transport";
+import { useAuthStore } from "@/stores/auth-store";
+
+export function useRegister() {
+  return useMutation({
+    mutationFn: async (params: {
+      gameName: string;
+      tagLine: string;
+      region: string;
+    }) => {
+      const res = await authClient.register(params);
+      return res;
+    },
+  });
+}
+
+export function useLogin() {
+  const setAuth = useAuthStore((s) => s.setAuth);
+
+  return useMutation({
+    mutationFn: async (accessKey: string) => {
+      const res = await authClient.login({ accessKey });
+      if (res.user && res.sessionToken) {
+        setAuth(res.sessionToken, res.user);
+      }
+      return res;
+    },
+  });
+}
+
+export function useCurrentUser() {
+  const token = useAuthStore((s) => s.token);
+
+  return useQuery({
+    queryKey: ["currentUser", token],
+    queryFn: () => authClient.getCurrentUser({}),
+    enabled: !!token,
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/frontend/src/lib/transport.ts
+++ b/frontend/src/lib/transport.ts
@@ -1,11 +1,29 @@
 import { createClient } from "@connectrpc/connect";
 import { createConnectTransport } from "@connectrpc/connect-web";
-import { PatchService } from "../gen/tft/v1/patch_pb";
-import { PlayerService } from "../gen/tft/v1/player_pb";
+import { PatchService } from "@/gen/tft/v1/patch_pb";
+import { PlayerService } from "@/gen/tft/v1/player_pb";
+import { AuthService } from "@/gen/tft/v1/auth_pb";
 
 export const transport = createConnectTransport({
   baseUrl: "http://localhost:8080",
+  interceptors: [
+    (next) => async (req) => {
+      const token = localStorage.getItem("tft-oracle-auth");
+      if (token) {
+        try {
+          const parsed = JSON.parse(token);
+          if (parsed?.state?.token) {
+            req.header.set("Authorization", `Bearer ${parsed.state.token}`);
+          }
+        } catch {
+          // ignore malformed storage
+        }
+      }
+      return next(req);
+    },
+  ],
 });
 
 export const patchClient = createClient(PatchService, transport);
 export const playerClient = createClient(PlayerService, transport);
+export const authClient = createClient(AuthService, transport);

--- a/frontend/src/pages/auth.tsx
+++ b/frontend/src/pages/auth.tsx
@@ -1,7 +1,5 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { SectionHeader } from "@/components/layout/section-header";
-import { TerminalCard } from "@/components/ui/terminal-card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useRegister, useLogin } from "@/hooks/use-auth";
@@ -24,25 +22,74 @@ export function AuthPage() {
   const [tab, setTab] = useState<"register" | "login">("register");
 
   return (
-    <div>
-      <SectionHeader number="00" title="authenticate" />
+    <div className="flex min-h-screen items-center justify-center bg-lofi-black">
+      {/* Dot grid background */}
+      <div
+        className="pointer-events-none fixed inset-0"
+        style={{
+          backgroundImage:
+            "radial-gradient(circle, #27272a 1px, transparent 1px)",
+          backgroundSize: "24px 24px",
+        }}
+      />
 
-      <div className="mb-4 flex gap-2">
-        <Button
-          variant={tab === "register" ? "primary" : "secondary"}
-          onClick={() => setTab("register")}
-        >
-          register
-        </Button>
-        <Button
-          variant={tab === "login" ? "primary" : "secondary"}
-          onClick={() => setTab("login")}
-        >
-          login
-        </Button>
+      <div className="relative z-10 w-full max-w-md px-6">
+        {/* Header */}
+        <div className="mb-8 text-center">
+          <div className="mb-4 inline-flex h-14 w-14 items-center justify-center rounded-lg border border-lofi-border bg-lofi-surface">
+            <span className="text-2xl font-bold text-lofi-accent">//</span>
+          </div>
+          <h1 className="text-lg font-bold tracking-wider text-white">
+            TFT_ORACLE
+          </h1>
+          <p className="mt-1 text-xs text-lofi-muted">
+            tactical intelligence system
+          </p>
+        </div>
+
+        {/* Tab switcher */}
+        <div className="mb-6 flex rounded-sm border border-lofi-border bg-lofi-black">
+          <button
+            onClick={() => setTab("register")}
+            className={`flex-1 py-2 text-xs font-medium transition-colors ${
+              tab === "register"
+                ? "bg-lofi-surface text-white"
+                : "text-lofi-muted hover:text-lofi-secondary"
+            }`}
+          >
+            register
+          </button>
+          <button
+            onClick={() => setTab("login")}
+            className={`flex-1 py-2 text-xs font-medium transition-colors ${
+              tab === "login"
+                ? "bg-lofi-surface text-white"
+                : "text-lofi-muted hover:text-lofi-secondary"
+            }`}
+          >
+            login
+          </button>
+        </div>
+
+        {/* Form card */}
+        <div className="rounded-lg border border-lofi-border bg-lofi-surface p-6">
+          {tab === "register" ? <RegisterForm /> : <LoginForm />}
+        </div>
+
+        {/* Footer */}
+        <div className="mt-6 text-center">
+          <p className="text-[10px] text-lofi-muted">
+            tft oracle is not affiliated with riot games
+          </p>
+          <div className="mt-2 flex items-center justify-center gap-3 text-[10px] text-lofi-muted">
+            <span className="flex items-center gap-1">
+              <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+              system: operational
+            </span>
+            <span>v0.2.0</span>
+          </div>
+        </div>
       </div>
-
-      {tab === "register" ? <RegisterForm /> : <LoginForm />}
     </div>
   );
 }
@@ -74,54 +121,57 @@ function RegisterForm() {
 
   if (accessKey) {
     return (
-      <TerminalCard className="max-w-lg border-l-2 border-l-lofi-accent">
-        <h3 className="mb-2 text-sm font-bold text-white">
-          registration complete
-        </h3>
-        <p className="mb-3 text-xs text-lofi-secondary">
-          Save this access key — it will only be shown once. Use it to log in
-          on any device.
+      <div>
+        <div className="mb-4 flex items-center gap-2">
+          <span className="flex h-6 w-6 items-center justify-center rounded-full bg-green-500/20 text-xs text-green-400">
+            ✓
+          </span>
+          <h3 className="text-sm font-bold text-white">
+            registration complete
+          </h3>
+        </div>
+
+        <p className="mb-4 text-xs leading-relaxed text-lofi-secondary">
+          Save this access key — it will only be shown{" "}
+          <span className="font-bold text-lofi-accent">once</span>. Use it to
+          log in on any device.
         </p>
 
-        <div className="mb-3 rounded-sm border border-lofi-border bg-lofi-black p-3">
-          <code className="break-all text-xs text-lofi-accent">{accessKey}</code>
+        <div className="mb-4 rounded-sm border border-lofi-accent/30 bg-lofi-black p-4">
+          <p className="mb-1 text-[10px] uppercase tracking-wider text-lofi-muted">
+            your access key
+          </p>
+          <code className="block break-all text-sm leading-relaxed text-lofi-accent">
+            {accessKey}
+          </code>
         </div>
 
         <div className="flex gap-2">
-          <Button onClick={handleCopy}>
+          <Button onClick={handleCopy} className="flex-1">
             {copied ? "copied!" : "copy key"}
           </Button>
           <Button
             variant="secondary"
-            onClick={() => {
-              // Auto-login after registration
-              navigate("/player");
-            }}
+            className="flex-1"
+            onClick={() => navigate("/player")}
           >
-            continue
+            continue →
           </Button>
         </div>
-
-        <p className="mt-3 text-[10px] text-lofi-muted">
-          you can now use this key to log in. keep it safe.
-        </p>
-      </TerminalCard>
+      </div>
     );
   }
 
   return (
-    <TerminalCard className="max-w-lg">
-      <h3 className="mb-1 text-sm font-bold text-white">
-        link your riot id
-      </h3>
-      <p className="mb-4 text-xs text-lofi-secondary">
-        verify your identity by entering your Riot ID. we'll generate a unique
-        access key for you.
+    <div>
+      <h3 className="mb-1 text-sm font-bold text-white">link your riot id</h3>
+      <p className="mb-5 text-xs text-lofi-secondary">
+        verify your identity to generate a unique access key.
       </p>
 
-      <form onSubmit={handleRegister} className="space-y-3">
+      <form onSubmit={handleRegister} className="space-y-4">
         <div>
-          <label className="mb-1 block text-[10px] uppercase tracking-wider text-lofi-muted">
+          <label className="mb-1.5 block text-[10px] uppercase tracking-wider text-lofi-muted">
             game name
           </label>
           <Input
@@ -131,9 +181,10 @@ function RegisterForm() {
             disabled={register.isPending}
           />
         </div>
+
         <div className="flex gap-3">
           <div className="flex-1">
-            <label className="mb-1 block text-[10px] uppercase tracking-wider text-lofi-muted">
+            <label className="mb-1.5 block text-[10px] uppercase tracking-wider text-lofi-muted">
               tag line
             </label>
             <Input
@@ -143,8 +194,8 @@ function RegisterForm() {
               disabled={register.isPending}
             />
           </div>
-          <div className="w-24">
-            <label className="mb-1 block text-[10px] uppercase tracking-wider text-lofi-muted">
+          <div className="w-28">
+            <label className="mb-1.5 block text-[10px] uppercase tracking-wider text-lofi-muted">
               server
             </label>
             <select
@@ -170,14 +221,24 @@ function RegisterForm() {
 
         <Button
           type="submit"
-          disabled={
-            register.isPending || !gameName.trim() || !tagLine.trim()
-          }
+          className="w-full"
+          disabled={register.isPending || !gameName.trim() || !tagLine.trim()}
         >
-          {register.isPending ? "verifying..." : "register"}
+          {register.isPending ? "verifying riot id..." : "register"}
         </Button>
       </form>
-    </TerminalCard>
+
+      <div className="mt-4 flex items-center justify-center gap-4 text-[10px] text-lofi-muted">
+        <span className="flex items-center gap-1">
+          <span className="h-1 w-1 rounded-full bg-green-500" />
+          encrypted
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="h-1 w-1 rounded-full bg-green-500" />
+          riot api verified
+        </span>
+      </div>
+    </div>
   );
 }
 
@@ -193,17 +254,15 @@ function LoginForm() {
   };
 
   return (
-    <TerminalCard className="max-w-lg">
-      <h3 className="mb-1 text-sm font-bold text-white">
-        enter access key
-      </h3>
-      <p className="mb-4 text-xs text-lofi-secondary">
+    <div>
+      <h3 className="mb-1 text-sm font-bold text-white">enter access key</h3>
+      <p className="mb-5 text-xs text-lofi-secondary">
         paste the access key you received during registration.
       </p>
 
-      <form onSubmit={handleLogin} className="space-y-3">
+      <form onSubmit={handleLogin} className="space-y-4">
         <div>
-          <label className="mb-1 block text-[10px] uppercase tracking-wider text-lofi-muted">
+          <label className="mb-1.5 block text-[10px] uppercase tracking-wider text-lofi-muted">
             access key
           </label>
           <Input
@@ -222,11 +281,17 @@ function LoginForm() {
 
         <Button
           type="submit"
+          className="w-full"
           disabled={login.isPending || !accessKey.trim()}
         >
           {login.isPending ? "authenticating..." : "login"}
         </Button>
       </form>
-    </TerminalCard>
+
+      <p className="mt-4 text-center text-[10px] text-lofi-muted">
+        don't have a key?{" "}
+        <span className="text-lofi-accent">switch to register tab above</span>
+      </p>
+    </div>
   );
 }

--- a/frontend/src/pages/auth.tsx
+++ b/frontend/src/pages/auth.tsx
@@ -1,0 +1,232 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { SectionHeader } from "@/components/layout/section-header";
+import { TerminalCard } from "@/components/ui/terminal-card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useRegister, useLogin } from "@/hooks/use-auth";
+
+const servers = [
+  { value: "br", label: "BR" },
+  { value: "na", label: "NA" },
+  { value: "euw", label: "EUW" },
+  { value: "eune", label: "EUNE" },
+  { value: "kr", label: "KR" },
+  { value: "jp", label: "JP" },
+  { value: "oce", label: "OCE" },
+  { value: "lan", label: "LAN" },
+  { value: "las", label: "LAS" },
+  { value: "tr", label: "TR" },
+  { value: "ru", label: "RU" },
+];
+
+export function AuthPage() {
+  const [tab, setTab] = useState<"register" | "login">("register");
+
+  return (
+    <div>
+      <SectionHeader number="00" title="authenticate" />
+
+      <div className="mb-4 flex gap-2">
+        <Button
+          variant={tab === "register" ? "primary" : "secondary"}
+          onClick={() => setTab("register")}
+        >
+          register
+        </Button>
+        <Button
+          variant={tab === "login" ? "primary" : "secondary"}
+          onClick={() => setTab("login")}
+        >
+          login
+        </Button>
+      </div>
+
+      {tab === "register" ? <RegisterForm /> : <LoginForm />}
+    </div>
+  );
+}
+
+function RegisterForm() {
+  const [gameName, setGameName] = useState("");
+  const [tagLine, setTagLine] = useState("");
+  const [region, setRegion] = useState("br");
+  const [accessKey, setAccessKey] = useState("");
+  const [copied, setCopied] = useState(false);
+  const register = useRegister();
+  const navigate = useNavigate();
+
+  const handleRegister = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await register.mutateAsync({
+      gameName: gameName.trim(),
+      tagLine: tagLine.trim(),
+      region,
+    });
+    setAccessKey(res.accessKey);
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(accessKey);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (accessKey) {
+    return (
+      <TerminalCard className="max-w-lg border-l-2 border-l-lofi-accent">
+        <h3 className="mb-2 text-sm font-bold text-white">
+          registration complete
+        </h3>
+        <p className="mb-3 text-xs text-lofi-secondary">
+          Save this access key — it will only be shown once. Use it to log in
+          on any device.
+        </p>
+
+        <div className="mb-3 rounded-sm border border-lofi-border bg-lofi-black p-3">
+          <code className="break-all text-xs text-lofi-accent">{accessKey}</code>
+        </div>
+
+        <div className="flex gap-2">
+          <Button onClick={handleCopy}>
+            {copied ? "copied!" : "copy key"}
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() => {
+              // Auto-login after registration
+              navigate("/player");
+            }}
+          >
+            continue
+          </Button>
+        </div>
+
+        <p className="mt-3 text-[10px] text-lofi-muted">
+          you can now use this key to log in. keep it safe.
+        </p>
+      </TerminalCard>
+    );
+  }
+
+  return (
+    <TerminalCard className="max-w-lg">
+      <h3 className="mb-1 text-sm font-bold text-white">
+        link your riot id
+      </h3>
+      <p className="mb-4 text-xs text-lofi-secondary">
+        verify your identity by entering your Riot ID. we'll generate a unique
+        access key for you.
+      </p>
+
+      <form onSubmit={handleRegister} className="space-y-3">
+        <div>
+          <label className="mb-1 block text-[10px] uppercase tracking-wider text-lofi-muted">
+            game name
+          </label>
+          <Input
+            value={gameName}
+            onChange={(e) => setGameName(e.target.value)}
+            placeholder="pai de olivia"
+            disabled={register.isPending}
+          />
+        </div>
+        <div className="flex gap-3">
+          <div className="flex-1">
+            <label className="mb-1 block text-[10px] uppercase tracking-wider text-lofi-muted">
+              tag line
+            </label>
+            <Input
+              value={tagLine}
+              onChange={(e) => setTagLine(e.target.value)}
+              placeholder="NIAS"
+              disabled={register.isPending}
+            />
+          </div>
+          <div className="w-24">
+            <label className="mb-1 block text-[10px] uppercase tracking-wider text-lofi-muted">
+              server
+            </label>
+            <select
+              value={region}
+              onChange={(e) => setRegion(e.target.value)}
+              disabled={register.isPending}
+              className="w-full rounded-sm border border-lofi-border bg-lofi-black px-3 py-1.5 text-xs text-lofi-text focus:border-lofi-accent focus:outline-none focus:ring-1 focus:ring-lofi-accent"
+            >
+              {servers.map((s) => (
+                <option key={s.value} value={s.value}>
+                  {s.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {register.error && (
+          <div className="rounded-sm border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+            {register.error.message}
+          </div>
+        )}
+
+        <Button
+          type="submit"
+          disabled={
+            register.isPending || !gameName.trim() || !tagLine.trim()
+          }
+        >
+          {register.isPending ? "verifying..." : "register"}
+        </Button>
+      </form>
+    </TerminalCard>
+  );
+}
+
+function LoginForm() {
+  const [accessKey, setAccessKey] = useState("");
+  const login = useLogin();
+  const navigate = useNavigate();
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await login.mutateAsync(accessKey.trim());
+    navigate("/player");
+  };
+
+  return (
+    <TerminalCard className="max-w-lg">
+      <h3 className="mb-1 text-sm font-bold text-white">
+        enter access key
+      </h3>
+      <p className="mb-4 text-xs text-lofi-secondary">
+        paste the access key you received during registration.
+      </p>
+
+      <form onSubmit={handleLogin} className="space-y-3">
+        <div>
+          <label className="mb-1 block text-[10px] uppercase tracking-wider text-lofi-muted">
+            access key
+          </label>
+          <Input
+            value={accessKey}
+            onChange={(e) => setAccessKey(e.target.value)}
+            placeholder="paste your access key..."
+            disabled={login.isPending}
+          />
+        </div>
+
+        {login.error && (
+          <div className="rounded-sm border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+            {login.error.message}
+          </div>
+        )}
+
+        <Button
+          type="submit"
+          disabled={login.isPending || !accessKey.trim()}
+        >
+          {login.isPending ? "authenticating..." : "login"}
+        </Button>
+      </form>
+    </TerminalCard>
+  );
+}

--- a/frontend/src/pages/player.tsx
+++ b/frontend/src/pages/player.tsx
@@ -5,10 +5,7 @@ import { usePatchLookup } from "@/hooks/use-patch-lookup";
 import { usePlayerStore } from "@/stores/player-store";
 import { SectionHeader } from "@/components/layout/section-header";
 import { RiotIdForm } from "@/components/player/riot-id-form";
-import { ProfileHeader } from "@/components/player/profile-header";
-import { MatchCard } from "@/components/player/match-card";
-import { AnalyticsPanel } from "@/components/player/analytics-panel";
-import { Skeleton } from "@/components/ui/skeleton";
+import { PlayerData } from "@/components/player/player-data";
 
 export function PlayerPage() {
   const { gameName, tagLine, region, puuid, setSearch, setPUUID } =
@@ -24,89 +21,24 @@ export function PlayerPage() {
     }
   }, [profile.data?.account?.puuid, setPUUID]);
 
-  const handleSearch = (gn: string, tl: string, r: string) => {
-    setSearch(gn, tl, r);
-  };
-
   return (
     <div>
-      <SectionHeader number="03" title="player" />
+      <SectionHeader number="04" title="player search" />
 
       <div className="mb-4">
-        <RiotIdForm onSubmit={handleSearch} isLoading={profile.isLoading} />
+        <RiotIdForm
+          onSubmit={(gn, tl, r) => setSearch(gn, tl, r)}
+          isLoading={profile.isLoading}
+        />
       </div>
 
-      {profile.error && (
-        <div className="mb-4 rounded-sm border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
-          {profile.error.message}
-        </div>
-      )}
-
-      {profile.isLoading && (
-        <div className="space-y-3">
-          <Skeleton className="h-20" />
-          <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
-            <Skeleton className="h-48" />
-            <Skeleton className="h-48" />
-            <Skeleton className="h-48" />
-          </div>
-        </div>
-      )}
-
-      {profile.data?.account && (
-        <div className="space-y-4">
-          <ProfileHeader
-            account={profile.data.account}
-            summoner={profile.data.summoner}
-            rankedEntries={profile.data.rankedEntries}
-          />
-
-          {matchHistory.data?.matches &&
-            matchHistory.data.matches.length > 0 && (
-              <>
-                <SectionHeader number="03.1" title="analytics" />
-                <AnalyticsPanel
-                  matches={matchHistory.data.matches}
-                  puuid={puuid}
-                />
-              </>
-            )}
-
-          <SectionHeader number="03.2" title="match history" />
-
-          {matchHistory.isLoading && (
-            <div className="space-y-2">
-              {Array.from({ length: 5 }).map((_, i) => (
-                <Skeleton key={i} className="h-20" />
-              ))}
-            </div>
-          )}
-
-          {matchHistory.error && (
-            <div className="rounded-sm border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
-              {matchHistory.error.message}
-            </div>
-          )}
-
-          {matchHistory.data?.matches && (
-            <>
-              <p className="mb-2 text-xs text-lofi-muted">
-                {matchHistory.data.matches.length} matches
-              </p>
-              <div className="space-y-2">
-                {matchHistory.data.matches.map((match) => (
-                  <MatchCard
-                    key={match.metadata?.matchId}
-                    match={match}
-                    playerPuuid={puuid}
-                    patchLookup={patchLookup}
-                  />
-                ))}
-              </div>
-            </>
-          )}
-        </div>
-      )}
+      <PlayerData
+        profile={profile}
+        matchHistory={matchHistory}
+        puuid={puuid}
+        patchLookup={patchLookup}
+        sectionPrefix="04"
+      />
     </div>
   );
 }

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -1,0 +1,79 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { usePlayerProfile } from "@/hooks/use-player-profile";
+import { useMatchHistory } from "@/hooks/use-match-history";
+import { usePatchLookup } from "@/hooks/use-patch-lookup";
+import { useAuthStore } from "@/stores/auth-store";
+import { useCurrentUser } from "@/hooks/use-auth";
+import { SectionHeader } from "@/components/layout/section-header";
+import { PlayerData } from "@/components/player/player-data";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function ProfilePage() {
+  const navigate = useNavigate();
+  const { token, user } = useAuthStore();
+  const currentUser = useCurrentUser();
+
+  // Use auth user data for auto-search
+  const authUser = currentUser.data?.user ?? user;
+  const gameName = authUser?.gameName ?? "";
+  const tagLine = authUser?.tagLine ?? "";
+  const region = authUser?.region ?? "";
+  const puuid = authUser?.puuid ?? "";
+
+  const profile = usePlayerProfile(gameName, tagLine, region);
+  const matchHistory = useMatchHistory(puuid, region);
+  const patchLookup = usePatchLookup();
+
+  // Redirect to auth if not logged in
+  useEffect(() => {
+    if (!token) {
+      navigate("/auth");
+    }
+  }, [token, navigate]);
+
+  if (!token) return null;
+
+  if (!authUser || (!gameName && !currentUser.isLoading)) {
+    return (
+      <div>
+        <SectionHeader number="03" title="profile" />
+        <div className="rounded-sm border border-lofi-border bg-lofi-surface p-6 text-center">
+          <p className="text-xs text-lofi-secondary">
+            no riot id linked to your account.
+          </p>
+          <p className="mt-1 text-[10px] text-lofi-muted">
+            use the player search to look up any player, or re-register with
+            your riot id.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (currentUser.isLoading) {
+    return (
+      <div>
+        <SectionHeader number="03" title="profile" />
+        <div className="space-y-3">
+          <Skeleton className="h-20" />
+          <Skeleton className="h-48" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <SectionHeader number="03" title="profile" />
+
+      <PlayerData
+        profile={profile}
+        matchHistory={matchHistory}
+        puuid={puuid}
+        patchLookup={patchLookup}
+        sectionPrefix="03"
+      />
+    </div>
+  );
+}

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { User } from "@/gen/tft/v1/auth_pb";
+
+interface AuthState {
+  token: string;
+  user: User | null;
+  setAuth: (token: string, user: User) => void;
+  logout: () => void;
+  isAuthenticated: () => boolean;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      token: "",
+      user: null,
+      setAuth: (token, user) => set({ token, user }),
+      logout: () => set({ token: "", user: null }),
+      isAuthenticated: () => !!get().token,
+    }),
+    {
+      name: "tft-oracle-auth",
+      partialize: (state) => ({ token: state.token }),
+    },
+  ),
+);

--- a/insomnia.json
+++ b/insomnia.json
@@ -15,7 +15,8 @@
       "parentId": "wrk_tft_oracle",
       "name": "Base Environment",
       "data": {
-        "base_url": "http://localhost:8080"
+        "base_url": "http://localhost:8080",
+        "session_token": ""
       }
     },
     {
@@ -24,8 +25,15 @@
       "parentId": "env_base",
       "name": "Local",
       "data": {
-        "base_url": "http://localhost:8080"
+        "base_url": "http://localhost:8080",
+        "session_token": ""
       }
+    },
+    {
+      "_id": "fld_auth",
+      "_type": "request_group",
+      "parentId": "wrk_tft_oracle",
+      "name": "AuthService"
     },
     {
       "_id": "fld_patch",
@@ -38,6 +46,52 @@
       "_type": "request_group",
       "parentId": "wrk_tft_oracle",
       "name": "PlayerService"
+    },
+    {
+      "_id": "req_register",
+      "_type": "request",
+      "parentId": "fld_auth",
+      "name": "Register",
+      "method": "POST",
+      "url": "{{ _.base_url }}/tft.v1.AuthService/Register",
+      "headers": [
+        { "name": "Content-Type", "value": "application/json" }
+      ],
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"gameName\": \"pai de olivia\",\n  \"tagLine\": \"NIAS\",\n  \"region\": \"br\"\n}"
+      }
+    },
+    {
+      "_id": "req_login",
+      "_type": "request",
+      "parentId": "fld_auth",
+      "name": "Login",
+      "method": "POST",
+      "url": "{{ _.base_url }}/tft.v1.AuthService/Login",
+      "headers": [
+        { "name": "Content-Type", "value": "application/json" }
+      ],
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"accessKey\": \"paste-your-access-key-here\"\n}"
+      }
+    },
+    {
+      "_id": "req_get_current_user",
+      "_type": "request",
+      "parentId": "fld_auth",
+      "name": "GetCurrentUser (requires JWT)",
+      "method": "POST",
+      "url": "{{ _.base_url }}/tft.v1.AuthService/GetCurrentUser",
+      "headers": [
+        { "name": "Content-Type", "value": "application/json" },
+        { "name": "Authorization", "value": "Bearer {{ _.session_token }}" }
+      ],
+      "body": {
+        "mimeType": "application/json",
+        "text": "{}"
+      }
     },
     {
       "_id": "req_get_patch_data",

--- a/migrations/000010_create_users.down.sql
+++ b/migrations/000010_create_users.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS users;

--- a/migrations/000010_create_users.up.sql
+++ b/migrations/000010_create_users.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE users (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    access_key_hash TEXT NOT NULL UNIQUE,
+    riot_puuid      TEXT NOT NULL DEFAULT '',
+    game_name       TEXT NOT NULL DEFAULT '',
+    tag_line        TEXT NOT NULL DEFAULT '',
+    region          TEXT NOT NULL DEFAULT '',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_users_puuid ON users(riot_puuid);

--- a/proto/tft/v1/auth.proto
+++ b/proto/tft/v1/auth.proto
@@ -1,0 +1,61 @@
+syntax = "proto3";
+
+package tft.v1;
+
+option go_package = "github.com/MeninoNias/tft-oracle/backend/gen/tft/v1;tftv1";
+
+// AuthService handles user registration and authentication.
+// Users authenticate via a randomly generated access key tied to their Riot ID.
+service AuthService {
+  // Register creates a new user by verifying their Riot ID and generating an access key.
+  rpc Register(RegisterRequest) returns (RegisterResponse);
+  // Login validates an access key and returns a JWT session token.
+  rpc Login(LoginRequest) returns (LoginResponse);
+  // GetCurrentUser returns the authenticated user's profile.
+  rpc GetCurrentUser(GetCurrentUserRequest) returns (GetCurrentUserResponse);
+}
+
+// --- Register ---
+
+message RegisterRequest {
+  string game_name = 1;
+  string tag_line = 2;
+  // Server code: "br", "na", "euw", "kr", etc.
+  string region = 3;
+}
+
+message RegisterResponse {
+  // The access key — shown to the user ONCE. Must be copied and saved.
+  string access_key = 1;
+  User user = 2;
+}
+
+// --- Login ---
+
+message LoginRequest {
+  string access_key = 1;
+}
+
+message LoginResponse {
+  // JWT session token (30-day expiry by default).
+  string session_token = 1;
+  User user = 2;
+}
+
+// --- GetCurrentUser ---
+
+message GetCurrentUserRequest {}
+
+message GetCurrentUserResponse {
+  User user = 1;
+}
+
+// --- User ---
+
+message User {
+  string id = 1;
+  string game_name = 2;
+  string tag_line = 3;
+  string region = 4;
+  string puuid = 5;
+}


### PR DESCRIPTION
## Overview

Lightweight authentication for TFT Oracle. No username/password — users authenticate via a **randomly generated access key** tied to their Riot ID.

Closes #45

---

## Flow

```
1. Register: User enters Riot ID (gameName#tagLine) + server
2. Backend: Verifies Riot ID via Account API → gets PUUID
3. Backend: Generates a cryptographically random access key
4. User: Sees the key once → copies it → stored locally in Tauri
5. Login: Access key → backend validates → returns JWT session token
6. Auto-login: Tauri sends stored JWT on app start
```

## Implementation Plan

### 1. Proto Contract
- [x] `AuthService` with `Register`, `Login`, `GetCurrentUser` RPCs
- [x] Request/Response messages for all endpoints
- [x] `User` message: id, gameName, tagLine, region, puuid

### 2. Database
- [x] `users` table: id (UUID PK), access_key_hash, riot_puuid, game_name, tag_line, region
- [x] sqlc queries: CreateUser, GetUserByID, GetUserByPUUID, GetUserByAccessKeyHash, UpdateLastSeen

### 3. Backend (`backend/internal/auth/`)
- [x] `service.go` — Register: verify Riot ID → create user → return access key
- [x] `service.go` — Login: validate access key (bcrypt) → generate JWT → return token
- [x] `service.go` — GetCurrentUser: require auth, return user from DB
- [x] `jwt.go` — HS256 token generation/validation with configurable expiry
- [x] `middleware.go` — Connect RPC interceptor validates JWT, injects claims into context
- [x] Access key: 32-byte crypto/rand → base64url encoded
- [x] Access key stored as bcrypt hash in DB
- [x] Wired into main.go with CORS Authorization header support

### 4. Frontend
- [x] `/auth` page with Register / Login tabs
- [x] Register: gameName + tagLine + server → shows access key (copy button)
- [x] Login: access key input → auto-redirect to player page
- [x] `auth-store.ts` — Zustand store with localStorage persistence
- [x] Auto-attach JWT to all RPC calls via transport interceptor
- [x] Sidebar shows user info when logged in, login link when not

### 5. Config
- [x] `JWT_SECRET` env variable
- [x] `JWT_EXPIRY` env variable (default: 720h = 30 days)
- [x] `.env.example` updated

---

## Key Decisions
- **No email required** — Riot ID is the identity
- **Access key over password** — crypto/rand generated, no weak passwords
- **bcrypt for key storage** — safe even if DB is compromised
- **JWT for sessions** — stateless, 30-day expiry
- **Login by scanning** — bcrypt can't be queried directly, so we scan users table (fine for small user base)

## Test Plan
- [x] Register with valid Riot ID → receive access key
- [x] Register with invalid Riot ID → error
- [x] Register duplicate Riot ID → AlreadyExists error
- [x] Login with valid key → receive JWT
- [x] Login with invalid key → Unauthenticated error
- [x] GetCurrentUser without JWT → 401
- [x] GetCurrentUser with valid JWT → user data
- [x] GetCurrentUser with expired JWT → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)