### PR TITLE
feat: user auth, onboarding flow, and error pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,9 @@ import { ItemsPage } from "@/pages/items";
 import { ProfilePage } from "@/pages/profile";
 import { PlayerPage } from "@/pages/player";
 import { AuthPage } from "@/pages/auth";
+import { NotFoundPage } from "@/pages/not-found";
+import { InternalErrorPage } from "@/pages/internal-error";
+import { UnauthorizedPage } from "@/pages/unauthorized";
 
 export function App() {
   return (
@@ -23,6 +26,9 @@ export function App() {
               <Route path="/items" element={<ItemsPage />} />
               <Route path="/profile" element={<ProfilePage />} />
               <Route path="/player" element={<PlayerPage />} />
+              <Route path="/error/500" element={<InternalErrorPage />} />
+              <Route path="/error/401" element={<UnauthorizedPage />} />
+              <Route path="*" element={<NotFoundPage />} />
             </Routes>
           </MainLayout>
         }

--- a/frontend/src/components/error/error-screen.tsx
+++ b/frontend/src/components/error/error-screen.tsx
@@ -1,0 +1,88 @@
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+interface ErrorScreenProps {
+  code: string;
+  title: string;
+  lines: string[];
+  fadedLine?: string;
+  statusLabel?: string;
+  transmissionId?: string;
+}
+
+export function ErrorScreen({
+  code,
+  title,
+  lines,
+  fadedLine,
+  statusLabel = "DISCONNECTED",
+  transmissionId = "TFT-ORCL-ERR-09X",
+}: ErrorScreenProps) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col items-center justify-center py-16">
+      {/* Big faded code behind title */}
+      <div className="relative mb-8 text-center">
+        <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 select-none font-mono text-[100px] font-black leading-none text-lofi-accent/5">
+          {code}
+        </span>
+        <h1 className="relative font-mono text-4xl font-black uppercase tracking-widest text-white">
+          ERROR
+        </h1>
+      </div>
+
+      {/* Error card */}
+      <div className="mb-8 w-full max-w-xl rounded-lg border border-lofi-accent/20 bg-lofi-surface/80 p-6 shadow-lg shadow-lofi-accent/5 backdrop-blur-sm">
+        <div className="mb-4 flex flex-col gap-2">
+          <p className="font-mono text-2xl font-black leading-tight tracking-tighter text-lofi-accent">
+            {code}: {title}
+          </p>
+          <div className="flex items-center gap-2">
+            <span className="h-2 w-2 animate-pulse rounded-full bg-red-500" />
+            <p className="font-mono text-xs uppercase tracking-widest text-lofi-muted">
+              status: {statusLabel}
+            </p>
+          </div>
+        </div>
+
+        <div className="mb-4 h-px w-full bg-lofi-accent/20" />
+
+        <div className="space-y-2 font-mono text-sm leading-relaxed opacity-80">
+          {lines.map((line, i) => (
+            <p key={i} className="flex gap-2 text-lofi-secondary">
+              <span className="text-lofi-accent">&gt;</span>
+              {line}
+            </p>
+          ))}
+          {fadedLine && (
+            <p className="flex gap-2 italic text-lofi-accent/30">
+              <span>&gt;</span>
+              {fadedLine}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex gap-3">
+        <Button onClick={() => navigate("/")}>home: return to base</Button>
+        <Button variant="secondary" onClick={() => navigate(-1 as never)}>
+          back: previous page
+        </Button>
+      </div>
+
+      {/* Footer */}
+      <div className="mt-10 flex flex-col items-center gap-3">
+        <div className="flex gap-3 opacity-40">
+          <span className="h-2 w-2 rounded-full bg-lofi-accent" />
+          <span className="h-2 w-2 rounded-full bg-lofi-accent" />
+          <span className="h-2 w-2 rounded-full bg-lofi-accent" />
+        </div>
+        <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-lofi-muted">
+          end of transmission // {transmissionId}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/onboarding/empty-state.tsx
+++ b/frontend/src/components/onboarding/empty-state.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@/components/ui/button";
+import { useNavigate } from "react-router-dom";
+
+interface EmptyStateProps {
+  onStartOnboarding: () => void;
+}
+
+export function EmptyState({ onStartOnboarding }: EmptyStateProps) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col items-center justify-center py-20">
+      {/* Icon */}
+      <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-lg border border-lofi-border bg-lofi-surface">
+        <span className="text-3xl font-bold text-lofi-accent">//</span>
+      </div>
+
+      {/* Heading */}
+      <h2 className="mb-2 text-sm font-bold uppercase tracking-widest text-white">
+        DATA_NOT_FOUND
+      </h2>
+
+      {/* Description */}
+      <p className="mb-8 max-w-sm text-center text-xs leading-relaxed text-lofi-secondary">
+        the oracle is silent. link your riot id to unlock tactical intelligence
+        — match history, ranked stats, and ai-powered coaching.
+      </p>
+
+      {/* Actions */}
+      <div className="flex gap-3">
+        <Button onClick={onStartOnboarding}>CONSULT_ORACLE</Button>
+        <Button variant="secondary" onClick={() => navigate("/player")}>
+          VIEW_DEMO_DATA
+        </Button>
+      </div>
+
+      {/* Status footer */}
+      <div className="mt-12 flex items-center gap-4 text-[10px] text-lofi-muted">
+        <span className="flex items-center gap-1">
+          <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+          system: operational
+        </span>
+        <span>v0.2.0</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/onboarding/onboarding-flow.tsx
+++ b/frontend/src/components/onboarding/onboarding-flow.tsx
@@ -1,0 +1,377 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useRegisterAndLogin } from "@/hooks/use-auth";
+import { SERVERS } from "@/lib/servers";
+import { friendlyError } from "@/lib/error";
+
+type Step = "identify" | "connect" | "augment";
+
+interface OnboardingFlowProps {
+  onComplete: () => void;
+}
+
+export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
+  const [step, setStep] = useState<Step>("identify");
+  const [gameName, setGameName] = useState("");
+  const [tagLine, setTagLine] = useState("");
+  const [region, setRegion] = useState("br");
+  const [accessKey, setAccessKey] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  const registerAndLogin = useRegisterAndLogin();
+  const navigate = useNavigate();
+
+  const handleSync = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStep("connect");
+    try {
+      const res = await registerAndLogin.mutateAsync({
+        gameName: gameName.trim(),
+        tagLine: tagLine.trim(),
+        region,
+      });
+      setAccessKey(res.accessKey);
+    } catch {
+      // Error is available via registerAndLogin.error
+    }
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(accessKey);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const steps: { key: Step; label: string }[] = [
+    { key: "identify", label: "IDENTIFY" },
+    { key: "connect", label: "CONNECT" },
+    { key: "augment", label: "AUGMENT" },
+  ];
+
+  const currentIndex = steps.findIndex((s) => s.key === step);
+
+  return (
+    <div className="mx-auto max-w-lg py-10">
+      {/* Step indicator */}
+      <div className="mb-8 flex items-center justify-center gap-6">
+        {steps.map((s, i) => (
+          <div key={s.key} className="flex items-center gap-2">
+            <span
+              className={`flex h-6 w-6 items-center justify-center rounded-full text-[10px] font-bold ${
+                i <= currentIndex
+                  ? "bg-lofi-accent text-lofi-black"
+                  : "border border-lofi-border text-lofi-muted"
+              }`}
+            >
+              {String(i + 1).padStart(2, "0")}
+            </span>
+            <span
+              className={`text-[10px] uppercase tracking-wider ${
+                i <= currentIndex ? "text-white" : "text-lofi-muted"
+              }`}
+            >
+              {s.label}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Step content */}
+      <div className="rounded-lg border border-lofi-border bg-lofi-surface p-6">
+        {step === "identify" && (
+          <IdentifyStep
+            gameName={gameName}
+            tagLine={tagLine}
+            region={region}
+            onGameNameChange={setGameName}
+            onTagLineChange={setTagLine}
+            onRegionChange={setRegion}
+            onSubmit={handleSync}
+            isPending={false}
+          />
+        )}
+
+        {step === "connect" && (
+          <ConnectStep
+            isPending={registerAndLogin.isPending}
+            error={registerAndLogin.error}
+            accessKey={accessKey}
+            copied={copied}
+            onCopy={handleCopy}
+            onContinue={() => setStep("augment")}
+            onRetry={() => {
+              registerAndLogin.reset();
+              setStep("identify");
+            }}
+          />
+        )}
+
+        {step === "augment" && (
+          <AugmentStep
+            gameName={gameName}
+            tagLine={tagLine}
+            onViewProfile={onComplete}
+            onPlayerSearch={() => navigate("/player")}
+            onChampions={() => navigate("/champions")}
+          />
+        )}
+      </div>
+
+      {/* Already registered link */}
+      {step === "identify" && (
+        <p className="mt-4 text-center text-[10px] text-lofi-muted">
+          already registered?{" "}
+          <button
+            onClick={() => navigate("/auth")}
+            className="text-lofi-accent hover:underline"
+          >
+            login with access key
+          </button>
+        </p>
+      )}
+    </div>
+  );
+}
+
+function IdentifyStep({
+  gameName,
+  tagLine,
+  region,
+  onGameNameChange,
+  onTagLineChange,
+  onRegionChange,
+  onSubmit,
+  isPending,
+}: {
+  gameName: string;
+  tagLine: string;
+  region: string;
+  onGameNameChange: (v: string) => void;
+  onTagLineChange: (v: string) => void;
+  onRegionChange: (v: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  isPending: boolean;
+}) {
+  return (
+    <div>
+      <h3 className="mb-1 text-sm font-bold text-white">
+        Welcome, Tactician.
+      </h3>
+      <p className="mb-5 text-xs text-lofi-secondary">
+        link your riot id to activate the oracle. your identity is verified
+        through the riot api — no password needed.
+      </p>
+
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div>
+          <label className="mb-1.5 block text-[10px] uppercase tracking-wider text-lofi-muted">
+            game name
+          </label>
+          <Input
+            value={gameName}
+            onChange={(e) => onGameNameChange(e.target.value)}
+            placeholder="pai de olivia"
+            disabled={isPending}
+          />
+        </div>
+
+        <div className="flex gap-3">
+          <div className="flex-1">
+            <label className="mb-1.5 block text-[10px] uppercase tracking-wider text-lofi-muted">
+              tag line
+            </label>
+            <Input
+              value={tagLine}
+              onChange={(e) => onTagLineChange(e.target.value)}
+              placeholder="NIAS"
+              disabled={isPending}
+            />
+          </div>
+          <div className="w-28">
+            <label className="mb-1.5 block text-[10px] uppercase tracking-wider text-lofi-muted">
+              server
+            </label>
+            <select
+              value={region}
+              onChange={(e) => onRegionChange(e.target.value)}
+              disabled={isPending}
+              className="w-full rounded-sm border border-lofi-border bg-lofi-black px-3 py-1.5 text-xs text-lofi-text focus:border-lofi-accent focus:outline-none focus:ring-1 focus:ring-lofi-accent"
+            >
+              {SERVERS.map((s) => (
+                <option key={s.value} value={s.value}>
+                  {s.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={isPending || !gameName.trim() || !tagLine.trim()}
+        >
+          SYNC_ACCOUNT
+        </Button>
+      </form>
+    </div>
+  );
+}
+
+function ConnectStep({
+  isPending,
+  error,
+  accessKey,
+  copied,
+  onCopy,
+  onContinue,
+  onRetry,
+}: {
+  isPending: boolean;
+  error: Error | null;
+  accessKey: string;
+  copied: boolean;
+  onCopy: () => void;
+  onContinue: () => void;
+  onRetry: () => void;
+}) {
+  if (isPending) {
+    return (
+      <div className="flex flex-col items-center py-8">
+        <div className="mb-4 h-8 w-8 animate-spin rounded-full border-2 border-lofi-border border-t-lofi-accent" />
+        <p className="text-xs text-lofi-secondary">
+          verifying riot id and generating access key...
+        </p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div>
+        <div className="mb-4 flex items-center gap-2">
+          <span className="flex h-6 w-6 items-center justify-center rounded-full bg-red-500/20 text-xs text-red-400">
+            !
+          </span>
+          <h3 className="text-sm font-bold text-white">
+            connection failed
+          </h3>
+        </div>
+        <div className="mb-4 rounded-sm border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+          {friendlyError(error)}
+        </div>
+        <Button onClick={onRetry} className="w-full">
+          back to step 1
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center gap-2">
+        <span className="flex h-6 w-6 items-center justify-center rounded-full bg-green-500/20 text-xs text-green-400">
+          ✓
+        </span>
+        <h3 className="text-sm font-bold text-white">connection established</h3>
+      </div>
+
+      <p className="mb-4 text-xs leading-relaxed text-lofi-secondary">
+        save this access key — it will only be shown{" "}
+        <span className="font-bold text-lofi-accent">once</span>. use it to log
+        in on any device.
+      </p>
+
+      <div className="mb-4 rounded-sm border border-lofi-accent/30 bg-lofi-black p-4">
+        <p className="mb-1 text-[10px] uppercase tracking-wider text-lofi-muted">
+          your access key
+        </p>
+        <code className="block break-all text-sm leading-relaxed text-lofi-accent">
+          {accessKey}
+        </code>
+      </div>
+
+      <div className="mb-4 flex gap-2">
+        <Button onClick={onCopy} variant="secondary" className="flex-1">
+          {copied ? "copied!" : "copy key"}
+        </Button>
+      </div>
+
+      {/* Status badges */}
+      <div className="mb-4 flex items-center justify-center gap-4 text-[10px] text-lofi-muted">
+        <span className="flex items-center gap-1">
+          <span className="h-1 w-1 rounded-full bg-green-500" />
+          ENCRYPTION_ACTIVE
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="h-1 w-1 rounded-full bg-green-500" />
+          RIOT_API_VERIFIED
+        </span>
+      </div>
+
+      <Button onClick={onContinue} className="w-full">
+        CONTINUE
+      </Button>
+    </div>
+  );
+}
+
+function AugmentStep({
+  gameName,
+  tagLine,
+  onViewProfile,
+  onPlayerSearch,
+  onChampions,
+}: {
+  gameName: string;
+  tagLine: string;
+  onViewProfile: () => void;
+  onPlayerSearch: () => void;
+  onChampions: () => void;
+}) {
+  return (
+    <div className="text-center">
+      <div className="mb-4 flex items-center justify-center gap-2">
+        <span className="flex h-6 w-6 items-center justify-center rounded-full bg-green-500/20 text-xs text-green-400">
+          ✓
+        </span>
+        <h3 className="text-sm font-bold text-white">oracle activated</h3>
+      </div>
+
+      <p className="mb-2 text-xs text-lofi-secondary">
+        linked as{" "}
+        <span className="font-bold text-lofi-accent">
+          {gameName}#{tagLine}
+        </span>
+      </p>
+
+      <p className="mb-6 text-xs text-lofi-muted">
+        tactical intelligence is now online. choose your next move.
+      </p>
+
+      <div className="flex flex-col gap-2">
+        <Button onClick={onViewProfile} className="w-full">
+          view profile
+        </Button>
+        <div className="flex gap-2">
+          <Button
+            variant="secondary"
+            className="flex-1"
+            onClick={onPlayerSearch}
+          >
+            player search
+          </Button>
+          <Button
+            variant="secondary"
+            className="flex-1"
+            onClick={onChampions}
+          >
+            champions
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/player/player-data.tsx
+++ b/frontend/src/components/player/player-data.tsx
@@ -3,6 +3,7 @@ import { ProfileHeader } from "@/components/player/profile-header";
 import { MatchCard } from "@/components/player/match-card";
 import { AnalyticsPanel } from "@/components/player/analytics-panel";
 import { Skeleton } from "@/components/ui/skeleton";
+import { friendlyError } from "@/lib/error";
 import type { PatchLookup } from "@/hooks/use-patch-lookup";
 import type { GetPlayerProfileResponse } from "@/gen/tft/v1/player_pb";
 import type { GetMatchHistoryResponse } from "@/gen/tft/v1/player_pb";
@@ -33,7 +34,7 @@ export function PlayerData({
   if (profile.error) {
     return (
       <div className="rounded-sm border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
-        {profile.error.message}
+        {friendlyError(profile.error)}
       </div>
     );
   }
@@ -87,7 +88,7 @@ export function PlayerData({
 
       {matchHistory.error && (
         <div className="rounded-sm border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
-          {matchHistory.error.message}
+          {friendlyError(matchHistory.error)}
         </div>
       )}
 

--- a/frontend/src/components/player/riot-id-form.tsx
+++ b/frontend/src/components/player/riot-id-form.tsx
@@ -1,25 +1,7 @@
 import { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-
-const servers = [
-  { value: "br", label: "BR" },
-  { value: "na", label: "NA" },
-  { value: "lan", label: "LAN" },
-  { value: "las", label: "LAS" },
-  { value: "oce", label: "OCE" },
-  { value: "euw", label: "EUW" },
-  { value: "eune", label: "EUNE" },
-  { value: "tr", label: "TR" },
-  { value: "ru", label: "RU" },
-  { value: "kr", label: "KR" },
-  { value: "jp", label: "JP" },
-  { value: "ph", label: "PH" },
-  { value: "sg", label: "SG" },
-  { value: "th", label: "TH" },
-  { value: "tw", label: "TW" },
-  { value: "vn", label: "VN" },
-];
+import { SERVERS } from "@/lib/servers";
 
 interface RiotIdFormProps {
   onSubmit: (gameName: string, tagLine: string, region: string) => void;
@@ -72,7 +54,7 @@ export function RiotIdForm({ onSubmit, isLoading }: RiotIdFormProps) {
           disabled={isLoading}
           className="w-full rounded-sm border border-lofi-border bg-lofi-black px-3 py-1.5 text-xs text-lofi-text focus:border-lofi-accent focus:outline-none focus:ring-1 focus:ring-lofi-accent"
         >
-          {servers.map((r) => (
+          {SERVERS.map((r) => (
             <option key={r.value} value={r.value}>
               {r.label}
             </option>

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { ConnectError, Code } from "@connectrpc/connect";
 import { authClient } from "@/lib/transport";
 import { useAuthStore } from "@/stores/auth-store";
 
@@ -29,12 +30,50 @@ export function useLogin() {
   });
 }
 
+export function useRegisterAndLogin() {
+  const setAuth = useAuthStore((s) => s.setAuth);
+
+  return useMutation({
+    mutationFn: async (params: {
+      gameName: string;
+      tagLine: string;
+      region: string;
+    }) => {
+      const registerRes = await authClient.register(params);
+      const loginRes = await authClient.login({
+        accessKey: registerRes.accessKey,
+      });
+      if (loginRes.user && loginRes.sessionToken) {
+        setAuth(loginRes.sessionToken, loginRes.user);
+      }
+      return {
+        accessKey: registerRes.accessKey,
+        user: loginRes.user,
+      };
+    },
+  });
+}
+
 export function useCurrentUser() {
   const token = useAuthStore((s) => s.token);
+  const logout = useAuthStore((s) => s.logout);
 
   return useQuery({
     queryKey: ["currentUser", token],
-    queryFn: () => authClient.getCurrentUser({}),
+    queryFn: async () => {
+      try {
+        return await authClient.getCurrentUser({});
+      } catch (err) {
+        // Stale/invalid token → clear auth state so UI falls back to onboarding
+        if (
+          err instanceof ConnectError &&
+          err.code === Code.Unauthenticated
+        ) {
+          logout();
+        }
+        throw err;
+      }
+    },
     enabled: !!token,
     retry: false,
     staleTime: 5 * 60 * 1000,

--- a/frontend/src/lib/error.ts
+++ b/frontend/src/lib/error.ts
@@ -1,0 +1,47 @@
+import { ConnectError, Code } from "@connectrpc/connect";
+
+const FRIENDLY_MESSAGES: Partial<Record<Code, string>> = {
+  [Code.Unauthenticated]: "session expired or invalid access key. please log in again.",
+  [Code.PermissionDenied]: "you don't have permission to perform this action.",
+  [Code.NotFound]: "the requested data could not be found.",
+  [Code.AlreadyExists]: "this riot id is already registered. use your access key to log in.",
+  [Code.Unavailable]: "server is temporarily unavailable. try again in a moment.",
+  [Code.Internal]: "an unexpected server error occurred. please try again.",
+  [Code.InvalidArgument]: "invalid input — please check your fields and try again.",
+  [Code.DeadlineExceeded]: "request timed out. please try again.",
+};
+
+/**
+ * Extracts a user-friendly message from a Connect RPC error or generic Error.
+ */
+export function friendlyError(err: Error | null): string {
+  if (!err) return "an unknown error occurred.";
+
+  if (err instanceof ConnectError) {
+    // Try to extract nested status message from the JSON payload
+    const nested = parseNestedMessage(err.rawMessage);
+    if (nested) return nested;
+
+    return FRIENDLY_MESSAGES[err.code] ?? err.rawMessage ?? err.message;
+  }
+
+  return err.message;
+}
+
+function parseNestedMessage(raw: string): string | null {
+  try {
+    // Handle: unauthorized: {"status":{"message":"Unknown apikey","status_code":401}}
+    const jsonStart = raw.indexOf("{");
+    if (jsonStart === -1) return null;
+    const parsed = JSON.parse(raw.slice(jsonStart));
+    if (parsed?.status?.message) {
+      return parsed.status.message.toLowerCase() + ".";
+    }
+    if (parsed?.message) {
+      return parsed.message.toLowerCase() + ".";
+    }
+  } catch {
+    // not JSON, ignore
+  }
+  return null;
+}

--- a/frontend/src/lib/servers.ts
+++ b/frontend/src/lib/servers.ts
@@ -1,0 +1,18 @@
+export const SERVERS = [
+  { value: "br", label: "BR" },
+  { value: "na", label: "NA" },
+  { value: "lan", label: "LAN" },
+  { value: "las", label: "LAS" },
+  { value: "oce", label: "OCE" },
+  { value: "euw", label: "EUW" },
+  { value: "eune", label: "EUNE" },
+  { value: "tr", label: "TR" },
+  { value: "ru", label: "RU" },
+  { value: "kr", label: "KR" },
+  { value: "jp", label: "JP" },
+  { value: "ph", label: "PH" },
+  { value: "sg", label: "SG" },
+  { value: "th", label: "TH" },
+  { value: "tw", label: "TW" },
+  { value: "vn", label: "VN" },
+];

--- a/frontend/src/pages/auth.tsx
+++ b/frontend/src/pages/auth.tsx
@@ -1,25 +1,17 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useRegister, useLogin } from "@/hooks/use-auth";
-
-const servers = [
-  { value: "br", label: "BR" },
-  { value: "na", label: "NA" },
-  { value: "euw", label: "EUW" },
-  { value: "eune", label: "EUNE" },
-  { value: "kr", label: "KR" },
-  { value: "jp", label: "JP" },
-  { value: "oce", label: "OCE" },
-  { value: "lan", label: "LAN" },
-  { value: "las", label: "LAS" },
-  { value: "tr", label: "TR" },
-  { value: "ru", label: "RU" },
-];
+import { SERVERS } from "@/lib/servers";
+import { friendlyError } from "@/lib/error";
 
 export function AuthPage() {
-  const [tab, setTab] = useState<"register" | "login">("register");
+  const [searchParams] = useSearchParams();
+  const isExpired = searchParams.get("expired") === "1";
+  const [tab, setTab] = useState<"register" | "login">(
+    isExpired ? "login" : "register",
+  );
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-lofi-black">
@@ -70,6 +62,18 @@ export function AuthPage() {
             login
           </button>
         </div>
+
+        {/* Expired session banner */}
+        {isExpired && (
+          <div className="mb-4 rounded-sm border border-yellow-500/30 bg-yellow-500/10 px-4 py-3">
+            <p className="text-xs font-medium text-yellow-400">
+              session expired or invalid access key.
+            </p>
+            <p className="mt-0.5 text-[10px] text-yellow-400/70">
+              please log in again to continue.
+            </p>
+          </div>
+        )}
 
         {/* Form card */}
         <div className="rounded-lg border border-lofi-border bg-lofi-surface p-6">
@@ -204,7 +208,7 @@ function RegisterForm() {
               disabled={register.isPending}
               className="w-full rounded-sm border border-lofi-border bg-lofi-black px-3 py-1.5 text-xs text-lofi-text focus:border-lofi-accent focus:outline-none focus:ring-1 focus:ring-lofi-accent"
             >
-              {servers.map((s) => (
+              {SERVERS.map((s) => (
                 <option key={s.value} value={s.value}>
                   {s.label}
                 </option>
@@ -215,7 +219,7 @@ function RegisterForm() {
 
         {register.error && (
           <div className="rounded-sm border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
-            {register.error.message}
+            {friendlyError(register.error)}
           </div>
         )}
 
@@ -275,7 +279,7 @@ function LoginForm() {
 
         {login.error && (
           <div className="rounded-sm border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
-            {login.error.message}
+            {friendlyError(login.error)}
           </div>
         )}
 

--- a/frontend/src/pages/internal-error.tsx
+++ b/frontend/src/pages/internal-error.tsx
@@ -1,0 +1,18 @@
+import { ErrorScreen } from "@/components/error/error-screen";
+
+export function InternalErrorPage() {
+  return (
+    <ErrorScreen
+      code="500"
+      title="SYSTEM_FAILURE"
+      statusLabel="CRITICAL"
+      lines={[
+        "Internal process terminated unexpectedly.",
+        "Core module returned non-zero exit code.",
+        "Tactical subsystem: UNRESPONSIVE.",
+      ]}
+      fadedLine="Initiating emergency protocol... [STANDBY]"
+      transmissionId="TFT-ORCL-ERR-500"
+    />
+  );
+}

--- a/frontend/src/pages/not-found.tsx
+++ b/frontend/src/pages/not-found.tsx
@@ -1,0 +1,18 @@
+import { ErrorScreen } from "@/components/error/error-screen";
+
+export function NotFoundPage() {
+  return (
+    <ErrorScreen
+      code="404"
+      title="NO_DATA_FOUND"
+      statusLabel="DISCONNECTED"
+      lines={[
+        "Critical failure in data retrieval.",
+        "Remote uplink terminated by host.",
+        "System pulse: OFFLINE.",
+      ]}
+      fadedLine="Attempting reconnection... [FAILED]"
+      transmissionId="TFT-ORCL-ERR-404"
+    />
+  );
+}

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { usePlayerProfile } from "@/hooks/use-player-profile";
 import { useMatchHistory } from "@/hooks/use-match-history";
@@ -8,11 +8,24 @@ import { useCurrentUser } from "@/hooks/use-auth";
 import { SectionHeader } from "@/components/layout/section-header";
 import { PlayerData } from "@/components/player/player-data";
 import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/onboarding/empty-state";
+import { OnboardingFlow } from "@/components/onboarding/onboarding-flow";
 
 export function ProfilePage() {
   const navigate = useNavigate();
-  const { token, user } = useAuthStore();
+  const { token, user, logout } = useAuthStore();
   const currentUser = useCurrentUser();
+  const [showOnboarding, setShowOnboarding] = useState(false);
+
+  // Stale/invalid token — logout and redirect to auth with expired flag
+  useEffect(() => {
+    if (currentUser.isError && token) {
+      logout();
+      navigate("/auth?expired=1", { replace: true });
+    }
+  }, [currentUser.isError, token, logout, navigate]);
+
+  const isAuthenticated = !!token && !currentUser.isError;
 
   // Use auth user data for auto-search
   const authUser = currentUser.data?.user ?? user;
@@ -25,28 +38,31 @@ export function ProfilePage() {
   const matchHistory = useMatchHistory(puuid, region);
   const patchLookup = usePatchLookup();
 
-  // Redirect to auth if not logged in
-  useEffect(() => {
-    if (!token) {
-      navigate("/auth");
-    }
-  }, [token, navigate]);
-
-  if (!token) return null;
-
-  if (!authUser || (!gameName && !currentUser.isLoading)) {
+  // Not authenticated — show onboarding flow
+  if (!isAuthenticated && !showOnboarding) {
     return (
       <div>
         <SectionHeader number="03" title="profile" />
-        <div className="rounded-sm border border-lofi-border bg-lofi-surface p-6 text-center">
-          <p className="text-xs text-lofi-secondary">
-            no riot id linked to your account.
-          </p>
-          <p className="mt-1 text-[10px] text-lofi-muted">
-            use the player search to look up any player, or re-register with
-            your riot id.
-          </p>
-        </div>
+        <EmptyState onStartOnboarding={() => setShowOnboarding(true)} />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated && showOnboarding) {
+    return (
+      <div>
+        <SectionHeader number="03" title="profile" />
+        <OnboardingFlow onComplete={() => setShowOnboarding(false)} />
+      </div>
+    );
+  }
+
+  // Authenticated but no gameName — show onboarding at identify step
+  if (!gameName && !currentUser.isLoading) {
+    return (
+      <div>
+        <SectionHeader number="03" title="profile" />
+        <OnboardingFlow onComplete={() => setShowOnboarding(false)} />
       </div>
     );
   }

--- a/frontend/src/pages/unauthorized.tsx
+++ b/frontend/src/pages/unauthorized.tsx
@@ -1,0 +1,78 @@
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+export function UnauthorizedPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col items-center justify-center py-16">
+      {/* Big faded code behind title */}
+      <div className="relative mb-8 text-center">
+        <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 select-none font-mono text-[100px] font-black leading-none text-lofi-accent/5">
+          401
+        </span>
+        <h1 className="relative font-mono text-4xl font-black uppercase tracking-widest text-white">
+          ERROR
+        </h1>
+      </div>
+
+      {/* Error card */}
+      <div className="mb-8 w-full max-w-xl rounded-lg border border-lofi-accent/20 bg-lofi-surface/80 p-6 shadow-lg shadow-lofi-accent/5 backdrop-blur-sm">
+        <div className="mb-4 flex flex-col gap-2">
+          <p className="font-mono text-2xl font-black leading-tight tracking-tighter text-lofi-accent">
+            401: ACCESS_DENIED
+          </p>
+          <div className="flex items-center gap-2">
+            <span className="h-2 w-2 animate-pulse rounded-full bg-red-500" />
+            <p className="font-mono text-xs uppercase tracking-widest text-lofi-muted">
+              status: UNAUTHORIZED
+            </p>
+          </div>
+        </div>
+
+        <div className="mb-4 h-px w-full bg-lofi-accent/20" />
+
+        <div className="space-y-2 font-mono text-sm leading-relaxed opacity-80">
+          <p className="flex gap-2 text-lofi-secondary">
+            <span className="text-lofi-accent">&gt;</span>
+            Access key invalid or expired.
+          </p>
+          <p className="flex gap-2 text-lofi-secondary">
+            <span className="text-lofi-accent">&gt;</span>
+            Identity verification failed.
+          </p>
+          <p className="flex gap-2 text-lofi-secondary">
+            <span className="text-lofi-accent">&gt;</span>
+            Clearance level: NONE.
+          </p>
+          <p className="flex gap-2 italic text-lofi-accent/30">
+            <span>&gt;</span>
+            Requesting re-authentication... [AWAITING]
+          </p>
+        </div>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex gap-3">
+        <Button onClick={() => navigate("/auth")}>
+          authenticate: login
+        </Button>
+        <Button variant="secondary" onClick={() => navigate("/")}>
+          home: return to base
+        </Button>
+      </div>
+
+      {/* Footer */}
+      <div className="mt-10 flex flex-col items-center gap-3">
+        <div className="flex gap-3 opacity-40">
+          <span className="h-2 w-2 rounded-full bg-lofi-accent" />
+          <span className="h-2 w-2 rounded-full bg-lofi-accent" />
+          <span className="h-2 w-2 rounded-full bg-lofi-accent" />
+        </div>
+        <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-lofi-muted">
+          end of transmission // TFT-ORCL-ERR-401
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Auth system**: AuthService proto, JWT + access key authentication, users table, frontend login/register
- **Onboarding flow**: 3-step wizard (IDENTIFY → CONNECT → AUGMENT) on `/profile` for unauthenticated users — replaces silent redirect to `/auth`
- **Error pages**: 404 (catch-all), 500 (internal), 401 (unauthorized) — lofi-themed, based on Stitch design
- **Friendly errors**: `friendlyError()` utility parses Connect RPC errors into human-readable messages across all error displays
- **Stale token handling**: auto-logout on 401 + redirect to `/auth?expired=1` with session-expired banner

## Test plan
- [x] Visit `/profile` unauthenticated → see DATA_NOT_FOUND empty state
- [x] Click CONSULT_ORACLE → 3-step onboarding wizard appears
- [x] Complete onboarding → profile loads with player data
- [x] Visit `/profile` with stale token → redirects to `/auth?expired=1` with yellow banner on login tab
- [x] Visit `/auth` independently → register + login still work
- [x] Navigate to unknown route → 404 error page renders
- [x] Visit `/error/500` and `/error/401` → themed error pages render
- [x] Invalid Riot ID during register → friendly error message (not raw JSON)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)