### PR TITLE
feat: augments page with tier filtering

### DIFF
--- a/backend/internal/cdragon/parser.go
+++ b/backend/internal/cdragon/parser.go
@@ -14,6 +14,7 @@ type ParsedSet struct {
 	Champions []ParsedChampion
 	Traits    []ParsedTrait
 	Items     []ParsedItem
+	Augments  []ParsedItem
 }
 
 type ParsedChampion struct {
@@ -158,9 +159,10 @@ func Parse(data *CDragonData) *ParsedSet {
 		})
 	}
 
-	// Filter items for current set
+	// Filter items and augments for current set
 	setPrefix := strings.ToLower(setData.Mutator)
 	items := filterItems(data.Items, setPrefix, setData.Number)
+	augments := filterAugments(data.Items, setData.Number)
 
 	return &ParsedSet{
 		Number:    setData.Number,
@@ -169,6 +171,7 @@ func Parse(data *CDragonData) *ParsedSet {
 		Champions: champions,
 		Traits:    traits,
 		Items:     items,
+		Augments:  augments,
 	}
 }
 
@@ -231,6 +234,56 @@ func filterItems(allItems []CDragonItem, setMutator string, setNumber int) []Par
 	}
 
 	return items
+}
+
+// filterAugments filters the global items list, keeping only augments for the current set.
+// Augments are identified by having a tag that equals "augment".
+func filterAugments(allItems []CDragonItem, setNumber int) []ParsedItem {
+	augments := make([]ParsedItem, 0)
+	setPrefix := strings.ToLower("tft" + itoa(setNumber) + "_")
+
+	for _, item := range allItems {
+		if !isAugment(item.Tags) {
+			continue
+		}
+
+		// Only include augments for the current set (apiName starts with tft{N}_)
+		// or generic augments (tft_augment_).
+		apiLower := strings.ToLower(item.APIName)
+		if !strings.HasPrefix(apiLower, setPrefix) && !strings.HasPrefix(apiLower, "tft_augment_") {
+			continue
+		}
+
+		// Skip augments with empty or template names
+		if item.Name == "" || strings.Contains(item.Name, "@") {
+			continue
+		}
+
+		augments = append(augments, ParsedItem{
+			APIName:            item.APIName,
+			Name:               item.Name,
+			Desc:               item.Desc,
+			Composition:        item.Composition,
+			Effects:            item.Effects,
+			IconURL:            ConvertIconPath(item.Icon),
+			AssociatedTraits:   item.AssociatedTraits,
+			IncompatibleTraits: item.IncompatibleTraits,
+			Tags:               item.Tags,
+			Unique:             item.Unique,
+		})
+	}
+
+	return augments
+}
+
+// isAugment returns true if the item's tags contain "augment".
+func isAugment(tags []string) bool {
+	for _, tag := range tags {
+		if strings.ToLower(tag) == "augment" {
+			return true
+		}
+	}
+	return false
 }
 
 // isRealItem returns true if the apiName represents a real equipable item.

--- a/backend/internal/cdragon/sync.go
+++ b/backend/internal/cdragon/sync.go
@@ -39,8 +39,8 @@ func (s *Syncer) Sync(ctx context.Context, locale string) error {
 		return fmt.Errorf("no current set found in cdragon data")
 	}
 
-	log.Printf("cdragon: syncing set %d (%s) — %d champions, %d traits, %d items",
-		parsed.Number, parsed.Name, len(parsed.Champions), len(parsed.Traits), len(parsed.Items))
+	log.Printf("cdragon: syncing set %d (%s) — %d champions, %d traits, %d items, %d augments",
+		parsed.Number, parsed.Name, len(parsed.Champions), len(parsed.Traits), len(parsed.Items), len(parsed.Augments))
 
 	if err := s.store(ctx, parsed); err != nil {
 		return fmt.Errorf("store cdragon data: %w", err)
@@ -220,6 +220,48 @@ func (s *Syncer) store(ctx context.Context, parsed *ParsedSet) error {
 		})
 		if err != nil {
 			return fmt.Errorf("upsert item %s: %w", item.APIName, err)
+		}
+	}
+
+	// 6. Insert augments (stored in the items table, differentiated by "augment" tag)
+	for _, aug := range parsed.Augments {
+		effectsJSON, err := json.Marshal(aug.Effects)
+		if err != nil {
+			return fmt.Errorf("marshal augment effects: %w", err)
+		}
+
+		composition := aug.Composition
+		if composition == nil {
+			composition = []string{}
+		}
+		assocTraits := aug.AssociatedTraits
+		if assocTraits == nil {
+			assocTraits = []string{}
+		}
+		incompTraits := aug.IncompatibleTraits
+		if incompTraits == nil {
+			incompTraits = []string{}
+		}
+		tags := aug.Tags
+		if tags == nil {
+			tags = []string{}
+		}
+
+		_, err = qtx.UpsertItem(ctx, generated.UpsertItemParams{
+			ApiName:            aug.APIName,
+			SetNumber:          setNumber,
+			Name:               aug.Name,
+			Description:        aug.Desc,
+			Composition:        composition,
+			Effects:            effectsJSON,
+			IconUrl:            aug.IconURL,
+			AssociatedTraits:   assocTraits,
+			IncompatibleTraits: incompTraits,
+			Tags:               tags,
+			IsUnique:           aug.Unique,
+		})
+		if err != nil {
+			return fmt.Errorf("upsert augment %s: %w", aug.APIName, err)
 		}
 	}
 

--- a/backend/internal/patch/service.go
+++ b/backend/internal/patch/service.go
@@ -59,6 +59,11 @@ func (s *Service) GetPatchData(
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
+	augments, err := s.queries.GetAugmentsBySet(ctx, set.Number)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
 	// Build champion trait map
 	championTraits := make(map[string][]string)
 	for _, c := range champions {
@@ -120,6 +125,22 @@ func (s *Service) GetPatchData(
 		})
 	}
 
+	pbAugments := make([]*tftv1.Item, 0, len(augments))
+	for _, a := range augments {
+		pbAugments = append(pbAugments, &tftv1.Item{
+			ApiName:            a.ApiName,
+			Name:               a.Name,
+			Desc:               a.Description,
+			Composition:        a.Composition,
+			Effects:            mapItemEffectsToProto(a.Effects),
+			IconUrl:            a.IconUrl,
+			AssociatedTraits:   a.AssociatedTraits,
+			IncompatibleTraits: a.IncompatibleTraits,
+			Tags:               a.Tags,
+			Unique:             a.IsUnique,
+		})
+	}
+
 	return connect.NewResponse(&tftv1.GetPatchDataResponse{
 		Set: &tftv1.SetMetadata{
 			Number:  set.Number,
@@ -129,5 +150,6 @@ func (s *Service) GetPatchData(
 		Champions: pbChampions,
 		Items:     pbItems,
 		Traits:    pbTraits,
+		Augments:  pbAugments,
 	}), nil
 }

--- a/backend/sqlc/queries/items.sql
+++ b/backend/sqlc/queries/items.sql
@@ -15,7 +15,10 @@ ON CONFLICT (api_name, set_number) DO UPDATE SET
 RETURNING *;
 
 -- name: GetItemsBySet :many
-SELECT * FROM items WHERE set_number = $1 ORDER BY name;
+SELECT * FROM items WHERE set_number = $1 AND NOT ('augment' = ANY(tags)) ORDER BY name;
+
+-- name: GetAugmentsBySet :many
+SELECT * FROM items WHERE set_number = $1 AND 'augment' = ANY(tags) ORDER BY name;
 
 -- name: DeleteItemsBySet :exec
 DELETE FROM items WHERE set_number = $1;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { AuthPage } from "@/pages/auth";
 import { NotFoundPage } from "@/pages/not-found";
 import { InternalErrorPage } from "@/pages/internal-error";
 import { UnauthorizedPage } from "@/pages/unauthorized";
+import { AugmentsPage } from "@/pages/augments";
 
 export function App() {
   return (
@@ -24,6 +25,7 @@ export function App() {
               <Route path="/" element={<Navigate to="/champions" replace />} />
               <Route path="/champions" element={<ChampionsPage />} />
               <Route path="/items" element={<ItemsPage />} />
+              <Route path="/augments" element={<AugmentsPage />} />
               <Route path="/profile" element={<ProfilePage />} />
               <Route path="/player" element={<PlayerPage />} />
               <Route path="/error/500" element={<InternalErrorPage />} />

--- a/frontend/src/components/augment-card.tsx
+++ b/frontend/src/components/augment-card.tsx
@@ -1,0 +1,61 @@
+import { type Item } from "../gen/tft/v1/patch_pb";
+import { TerminalCard } from "./ui/terminal-card";
+import { Badge } from "./ui/badge";
+
+interface AugmentCardProps {
+  augment: Item;
+}
+
+function getAugmentTier(tags: string[]): string | null {
+  for (const tag of tags) {
+    const lower = tag.toLowerCase();
+    if (lower.includes("prismatic")) return "prismatic";
+    if (lower.includes("gold")) return "gold";
+    if (lower.includes("silver")) return "silver";
+  }
+  return null;
+}
+
+const tierStyles: Record<string, string> = {
+  silver: "border-gray-400 text-gray-400",
+  gold: "border-yellow-500 text-yellow-500",
+  prismatic: "border-purple-400 text-purple-400",
+};
+
+export function AugmentCard({ augment }: AugmentCardProps) {
+  const tier = getAugmentTier(augment.tags);
+
+  return (
+    <TerminalCard>
+      <div className="flex items-start gap-3">
+        {augment.iconUrl ? (
+          <img
+            src={augment.iconUrl}
+            alt={augment.name}
+            className="h-10 w-10 rounded-sm bg-lofi-black object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-10 w-10 items-center justify-center rounded-sm bg-lofi-black text-[10px] text-lofi-muted">
+            ?
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-xs font-medium text-white">
+              {augment.name}
+            </span>
+            {tier && (
+              <Badge className={tierStyles[tier]}>{tier}</Badge>
+            )}
+          </div>
+          {augment.desc && (
+            <p className="mt-1 line-clamp-2 text-[10px] leading-relaxed text-lofi-secondary">
+              {augment.desc.replace(/<[^>]*>/g, "")}
+            </p>
+          )}
+        </div>
+      </div>
+    </TerminalCard>
+  );
+}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -4,6 +4,7 @@ import { useAuthStore } from "@/stores/auth-store";
 const navItems = [
   { to: "/champions", label: "champions" },
   { to: "/items", label: "items" },
+  { to: "/augments", label: "augments" },
   { to: "/profile", label: "profile" },
   { to: "/player", label: "player search" },
 ];

--- a/frontend/src/pages/augments.tsx
+++ b/frontend/src/pages/augments.tsx
@@ -1,0 +1,87 @@
+import { useState, useMemo } from "react";
+import { usePatchData } from "@/hooks/use-patch-data";
+import { SectionHeader } from "@/components/layout/section-header";
+import { SearchFilterBar } from "@/components/search-filter-bar";
+import { AugmentCard } from "@/components/augment-card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const tierFilters = [
+  { label: "silver", value: "silver" },
+  { label: "gold", value: "gold" },
+  { label: "prismatic", value: "prismatic" },
+];
+
+function getAugmentTier(tags: string[]): string | null {
+  for (const tag of tags) {
+    const lower = tag.toLowerCase();
+    if (lower.includes("prismatic")) return "prismatic";
+    if (lower.includes("gold")) return "gold";
+    if (lower.includes("silver")) return "silver";
+  }
+  return null;
+}
+
+export function AugmentsPage() {
+  const { data, isLoading, error } = usePatchData();
+  const [search, setSearch] = useState("");
+  const [tierFilter, setTierFilter] = useState("all");
+
+  const filtered = useMemo(() => {
+    if (!data?.augments) return [];
+    return data.augments.filter((aug) => {
+      const matchesSearch = aug.name
+        .toLowerCase()
+        .includes(search.toLowerCase());
+
+      let matchesTier = true;
+      if (tierFilter !== "all") {
+        matchesTier = getAugmentTier(aug.tags) === tierFilter;
+      }
+
+      return matchesSearch && matchesTier;
+    });
+  }, [data?.augments, search, tierFilter]);
+
+  if (error) {
+    return (
+      <div className="text-xs text-red-400">
+        error: {error.message}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <SectionHeader number="05" title="augments" />
+
+      <SearchFilterBar
+        searchValue={search}
+        onSearchChange={setSearch}
+        searchPlaceholder="search augments..."
+        filters={tierFilters}
+        activeFilter={tierFilter}
+        onFilterChange={setTierFilter}
+      />
+
+      {isLoading ? (
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <Skeleton key={i} className="h-20" />
+          ))}
+        </div>
+      ) : (
+        <>
+          <p className="mb-3 text-[10px] text-lofi-muted">
+            {filtered.length} augment{filtered.length !== 1 ? "s" : ""}
+            {data?.set ? ` // set ${data.set.number}` : ""}
+          </p>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+            {filtered.map((aug) => (
+              <AugmentCard key={aug.apiName} augment={aug} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/proto/tft/v1/patch.proto
+++ b/proto/tft/v1/patch.proto
@@ -23,6 +23,9 @@ message GetPatchDataResponse {
   repeated Champion champions = 2;
   repeated Item items = 3;
   repeated Trait traits = 4;
+  // Augments are items with the "augment" tag. Tier is derived from tags:
+  // "augment_tier_silver", "augment_tier_gold", "augment_tier_prismatic".
+  repeated Item augments = 5;
 }
 
 // --- Set Metadata ---


### PR DESCRIPTION
## Summary
- Parse augments from CommunityDragon data (`items[]` where tags contain `"augment"`)
- Store in existing `items` table, differentiated by tag — no new migration needed
- `GetItemsBySet` excludes augments, new `GetAugmentsBySet` query filters for them
- Proto: added `repeated Item augments = 5` to `GetPatchDataResponse`
- Frontend: `/augments` page with search + silver/gold/prismatic tier filter
- `AugmentCard` component with tier-colored badges

## Test plan
- [ ] Run `buf generate` and `sqlc generate` — no errors
- [ ] Start backend → CommunityDragon sync logs augment count
- [ ] `/augments` page shows all augments with icons and descriptions
- [ ] Search filters augments by name
- [ ] Tier filter (silver/gold/prismatic) filters correctly
- [ ] `/items` page still shows only equippable items (no augments)
- [ ] Sidebar shows augments nav entry between items and profile

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)