### PR TITLE
feat: light/dark theme + UX polish (toasts, transitions, shimmer)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,7 @@
       rel="stylesheet"
     />
   </head>
-  <body class="bg-lofi-black text-white antialiased">
+  <body class="bg-lofi-black text-lofi-text antialiased">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,10 +12,12 @@ import { UnauthorizedPage } from "@/pages/unauthorized";
 import { AugmentsPage } from "@/pages/augments";
 import { SettingsPage } from "@/pages/settings";
 import { SplashScreen } from "@/components/splash-screen";
+import { useTheme } from "@/hooks/use-theme";
 
 const SPLASH_KEY = "tft-oracle-splash-seen";
 
 export function App() {
+  useTheme();
   const [showSplash, setShowSplash] = useState(
     () => !sessionStorage.getItem(SPLASH_KEY),
   );

--- a/frontend/src/components/layout/main-layout.tsx
+++ b/frontend/src/components/layout/main-layout.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from "react";
 import { Sidebar } from "./sidebar";
+import { PageTransition } from "../ui/page-transition";
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -9,7 +10,9 @@ export function MainLayout({ children }: MainLayoutProps) {
   return (
     <div className="flex h-screen bg-lofi-black">
       <Sidebar />
-      <main className="flex-1 overflow-y-auto p-6">{children}</main>
+      <main className="flex-1 overflow-y-auto p-6">
+        <PageTransition>{children}</PageTransition>
+      </main>
     </div>
   );
 }

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -14,9 +14,9 @@ export function Button({
     "inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-lofi-accent disabled:pointer-events-none disabled:opacity-50";
 
   const variants = {
-    primary: "bg-white text-black hover:bg-lofi-text",
+    primary: "bg-lofi-text text-lofi-black hover:opacity-80",
     secondary:
-      "border border-lofi-border bg-transparent text-lofi-text hover:bg-lofi-surface hover:text-white",
+      "border border-lofi-border bg-transparent text-lofi-text hover:bg-lofi-surface",
   };
 
   return (

--- a/frontend/src/components/ui/page-transition.tsx
+++ b/frontend/src/components/ui/page-transition.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+
+export function PageTransition({ children }: { children: React.ReactNode }) {
+  const location = useLocation();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(false);
+    const raf = requestAnimationFrame(() => setVisible(true));
+    return () => cancelAnimationFrame(raf);
+  }, [location.pathname]);
+
+  return (
+    <div
+      className={`transition-all duration-200 ease-out ${
+        visible ? "translate-y-0 opacity-100" : "translate-y-1 opacity-0"
+      }`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -5,7 +5,9 @@ interface SkeletonProps {
 export function Skeleton({ className = "" }: SkeletonProps) {
   return (
     <div
-      className={`animate-pulse rounded-sm bg-lofi-muted ${className}`}
-    />
+      className={`relative overflow-hidden rounded-sm bg-lofi-border ${className}`}
+    >
+      <div className="absolute inset-0 -translate-x-full animate-[shimmer_1.5s_infinite] bg-gradient-to-r from-transparent via-lofi-muted/20 to-transparent" />
+    </div>
   );
 }

--- a/frontend/src/components/ui/terminal-card.tsx
+++ b/frontend/src/components/ui/terminal-card.tsx
@@ -8,7 +8,7 @@ interface TerminalCardProps {
 export function TerminalCard({ children, className = "" }: TerminalCardProps) {
   return (
     <div
-      className={`rounded-sm border border-lofi-border bg-lofi-surface p-4 ${className}`}
+      className={`rounded-sm border border-lofi-border bg-lofi-surface p-4 transition-colors duration-150 hover:border-lofi-muted ${className}`}
     >
       {children}
     </div>

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -1,0 +1,87 @@
+import { useState, useEffect, useCallback, createContext, useContext } from "react";
+
+type ToastType = "success" | "error" | "info";
+
+interface Toast {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
+interface ToastContextValue {
+  toast: (message: string, type?: ToastType) => void;
+}
+
+const ToastContext = createContext<ToastContextValue>({
+  toast: () => {},
+});
+
+export function useToast() {
+  return useContext(ToastContext);
+}
+
+let nextId = 0;
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const addToast = useCallback((message: string, type: ToastType = "info") => {
+    const id = nextId++;
+    setToasts((prev) => [...prev, { id, message, type }]);
+  }, []);
+
+  const removeToast = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ toast: addToast }}>
+      {children}
+      <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+        {toasts.map((t) => (
+          <ToastItem key={t.id} toast={t} onDismiss={removeToast} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+const typeStyles: Record<ToastType, string> = {
+  success: "border-green-500/30 bg-green-500/10 text-green-400",
+  error: "border-red-500/30 bg-red-500/10 text-red-400",
+  info: "border-lofi-accent/30 bg-lofi-accent/10 text-lofi-accent",
+};
+
+function ToastItem({
+  toast,
+  onDismiss,
+}: {
+  toast: Toast;
+  onDismiss: (id: number) => void;
+}) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // Trigger enter animation
+    requestAnimationFrame(() => setVisible(true));
+
+    const timer = setTimeout(() => {
+      setVisible(false);
+      setTimeout(() => onDismiss(toast.id), 200);
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, [toast.id, onDismiss]);
+
+  return (
+    <div
+      className={`rounded-sm border px-4 py-2 text-xs font-medium shadow-lg backdrop-blur-sm transition-all duration-200 ${typeStyles[toast.type]} ${
+        visible
+          ? "translate-x-0 opacity-100"
+          : "translate-x-4 opacity-0"
+      }`}
+    >
+      {toast.message}
+    </div>
+  );
+}

--- a/frontend/src/hooks/use-theme.ts
+++ b/frontend/src/hooks/use-theme.ts
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useSettingsStore } from "@/stores/settings-store";
+
+/**
+ * Applies the current theme from settings store to the <html> element.
+ * Call once at the app root.
+ */
+export function useTheme() {
+  const theme = useSettingsStore((s) => s.theme);
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+  }, [theme]);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,13 +4,16 @@ import { BrowserRouter } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "./lib/query-client";
 import { App } from "./App";
+import { ToastProvider } from "./components/ui/toast";
 import "./styles/globals.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
-        <App />
+        <ToastProvider>
+          <App />
+        </ToastProvider>
       </QueryClientProvider>
     </BrowserRouter>
   </StrictMode>,

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -22,6 +22,34 @@
     Menlo, Consolas, monospace;
 }
 
+/* Light theme — override lofi palette CSS variables */
+[data-theme="light"] {
+  --color-lofi-black: #ffffff;
+  --color-lofi-surface: #f4f4f5;
+  --color-lofi-border: #e4e4e7;
+  --color-lofi-muted: #a1a1aa;
+  --color-lofi-secondary: #64748b;
+  --color-lofi-text: #18181b;
+  --color-lofi-accent: #f97316;
+}
+
+/*
+ * In light theme, text-white (Tailwind utility = #fff) becomes invisible
+ * on white backgrounds. Remap it to the themed foreground color.
+ * This is safe because no component in this codebase uses text-white
+ * on a colored (non-lofi) background.
+ */
+[data-theme="light"] .text-white {
+  color: var(--color-lofi-text);
+}
+
+/* Shimmer animation for skeleton loading */
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
 * {
   font-family: var(--font-mono);
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## Summary
**Theme (#46):**
- Light/dark theme switching via CSS custom properties on `[data-theme]` attribute
- Light palette: white backgrounds, light gray surfaces, dark text, orange accent preserved
- `useTheme` hook reads settings store and applies `data-theme` to `<html>`
- Button component uses themed colors (`bg-lofi-text`/`text-lofi-black`)
- `text-white` remapped to foreground in light theme via CSS override
- Toggle already works from settings page

**UX Polish (#17):**
- Toast notification system (`useToast` hook) with success/error/info types and slide-in animation
- Page transition animations (fade + slight slide-up) on route changes
- Skeleton shimmer animation (gradient sweep replaces static pulse)
- Card hover effect (border highlight on hover)

## Test plan
- [x] Settings → toggle theme to light → entire app switches to light palette
- [x] Toggle back to dark → returns to original dark theme
- [x] Refresh page → theme persists (localStorage)
- [x] Navigate between pages → smooth fade transition
- [x] Loading states → skeleton shows shimmer animation
- [x] Hover over champion/item/augment cards → border highlights
- [x] `useToast` hook available for future toast notifications

Closes #46, partially addresses #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)