### PR TITLE
feat: Phase 4 — Crawler, Consolidation Engine, Super Tier List, UX Polish, Build Pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-tauri:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Buf CLI
+        uses: bufbuild/buf-setup-action@v1
+
+      - name: Generate protobuf code
+        run: buf generate
+
+      - name: Build Tauri
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: "TFT Oracle ${{ github.ref_name }}"
+          releaseBody: "See the assets to download this version."
+          releaseDraft: true
+          prerelease: false

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -161,3 +161,12 @@ tasks:
     dir: "{{.TAURI_DIR}}"
     cmds:
       - cargo tauri build
+
+  # ========================
+  # Release
+  # ========================
+  release:
+    desc: Create a release tag and push (triggers GitHub Actions)
+    cmds:
+      - git tag -a v{{.CLI_ARGS}} -m "Release v{{.CLI_ARGS}}"
+      - git push origin v{{.CLI_ARGS}}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -23,11 +23,14 @@ import (
 	"github.com/MeninoNias/tft-oracle/backend/internal/cache"
 	"github.com/MeninoNias/tft-oracle/backend/internal/cdragon"
 	"github.com/MeninoNias/tft-oracle/backend/internal/config"
+	"github.com/MeninoNias/tft-oracle/backend/internal/consolidation"
+	"github.com/MeninoNias/tft-oracle/backend/internal/crawler"
 	"github.com/MeninoNias/tft-oracle/backend/internal/database"
 	"github.com/MeninoNias/tft-oracle/backend/internal/patch"
 	"github.com/MeninoNias/tft-oracle/backend/internal/player"
 	"github.com/MeninoNias/tft-oracle/backend/internal/riot"
 	"github.com/MeninoNias/tft-oracle/backend/internal/simulation"
+	"github.com/MeninoNias/tft-oracle/backend/internal/tierlist"
 )
 
 func main() {
@@ -122,6 +125,28 @@ func main() {
 		log.Println("openai: OPENAI_API_KEY not set — simulation features disabled")
 	}
 
+	// Crawler & consolidation (Phase 4)
+	consolidationEngine := consolidation.NewEngine(pool, nil)
+	httpClient := crawler.NewHTTPClient()
+	scrapers := []crawler.Scraper{
+		crawler.NewMobalyticsScraper(httpClient),
+		crawler.NewTacticsToolsScraper(httpClient),
+		crawler.NewMetaTFTScraper(httpClient),
+	}
+
+	crawlerInterval := 24 * time.Hour
+	if d, err := time.ParseDuration(cfg.CrawlerInterval); err == nil {
+		crawlerInterval = d
+	}
+
+	crawl := crawler.New(pool, scrapers, crawlerInterval, consolidationEngine.Consolidate)
+	if cfg.CrawlerEnabled {
+		go crawl.StartScheduler(ctx)
+		log.Println("crawler: enabled")
+	} else {
+		log.Println("crawler: disabled")
+	}
+
 	// Set up Connect RPC handlers
 	mux := http.NewServeMux()
 
@@ -153,6 +178,12 @@ func main() {
 		interceptors,
 	)
 	mux.Handle(simPath, simHandler)
+
+	tierListPath, tierListHandler := tftv1connect.NewTierListServiceHandler(
+		tierlist.NewService(pool, crawl),
+		interceptors,
+	)
+	mux.Handle(tierListPath, tierListHandler)
 
 	// CORS configuration
 	corsHandler := cors.New(cors.Options{

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -22,6 +22,10 @@ type Config struct {
 	// Auth
 	JWTSecret string
 	JWTExpiry string // duration string, e.g. "720h" for 30 days
+
+	// Phase 4: Crawler
+	CrawlerInterval string // duration string, e.g. "24h"
+	CrawlerEnabled  bool
 }
 
 func Load() (*Config, error) {
@@ -34,8 +38,10 @@ func Load() (*Config, error) {
 		RiotAPIKey:  getEnv("RIOT_API_KEY", ""),
 		RedisURL:    getEnv("REDIS_URL", "redis://localhost:6379"),
 		OpenAIAPIKey: getEnv("OPENAI_API_KEY", ""),
-		JWTSecret:    getEnv("JWT_SECRET", ""),
-		JWTExpiry:   getEnv("JWT_EXPIRY", "720h"),
+		JWTSecret:       getEnv("JWT_SECRET", ""),
+		JWTExpiry:       getEnv("JWT_EXPIRY", "720h"),
+		CrawlerInterval: getEnv("CRAWLER_INTERVAL", "24h"),
+		CrawlerEnabled:  getEnv("CRAWLER_ENABLED", "true") == "true",
 	}
 
 	if cfg.DatabaseURL == "" {

--- a/backend/internal/consolidation/engine.go
+++ b/backend/internal/consolidation/engine.go
@@ -1,0 +1,159 @@
+package consolidation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/big"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/MeninoNias/tft-oracle/backend/sqlc/generated"
+)
+
+// Engine consolidates raw tier data from multiple sources into a unified tier list.
+type Engine struct {
+	db      *pgxpool.Pool
+	queries *generated.Queries
+	weights map[string]float64
+}
+
+// NewEngine creates a new consolidation engine.
+func NewEngine(db *pgxpool.Pool, weights map[string]float64) *Engine {
+	if weights == nil {
+		weights = DefaultWeights
+	}
+	return &Engine{
+		db:      db,
+		queries: generated.New(db),
+		weights: weights,
+	}
+}
+
+// Consolidate fetches raw tier data for a patch, matches compositions,
+// scores them, and stores the results.
+func (e *Engine) Consolidate(ctx context.Context, patch string) error {
+	log.Printf("consolidation: processing patch %s...", patch)
+
+	// 1. Fetch all raw data for this patch
+	rawData, err := e.queries.GetRawTierDataByPatch(ctx, patch)
+	if err != nil {
+		return fmt.Errorf("fetch raw data: %w", err)
+	}
+
+	if len(rawData) == 0 {
+		log.Printf("consolidation: no raw data for patch %s", patch)
+		return nil
+	}
+
+	// 2. Group by source and normalize
+	bySource := make(map[string][]NormalizedComp)
+	for _, row := range rawData {
+		comp := NormalizedComp{
+			Source:      row.Source,
+			Name:        row.CompositionName,
+			Tier:        textToString(row.Tier),
+			Score:       TierToScore[textToString(row.Tier)],
+			WinRate:     numericToFloat(row.WinRate),
+			PlayRate:    numericToFloat(row.PlayRate),
+			AvgPlacement: numericToFloat(row.AvgPlacement),
+			ChampionIDs: row.ChampionIds,
+		}
+
+		// Parse core items from JSONB
+		if len(row.CoreItems) > 0 {
+			var items map[string][]string
+			if err := json.Unmarshal(row.CoreItems, &items); err == nil {
+				comp.CoreItems = items
+			}
+		}
+		if comp.CoreItems == nil {
+			comp.CoreItems = make(map[string][]string)
+		}
+
+		bySource[row.Source] = append(bySource[row.Source], comp)
+	}
+
+	// 3. Match compositions across sources
+	groups := MatchCompositions(bySource)
+	log.Printf("consolidation: matched %d raw entries into %d composition groups", len(rawData), len(groups))
+
+	// 4. Score each group
+	results := make([]ConsolidatedResult, 0, len(groups))
+	for _, group := range groups {
+		result := ScoreGroup(group, e.weights)
+		results = append(results, result)
+	}
+
+	// 5. Store consolidated results
+	for _, r := range results {
+		itemsJSON, err := json.Marshal(r.RecommendedItems)
+		if err != nil {
+			return fmt.Errorf("marshal items for %q: %w", r.Name, err)
+		}
+
+		champions := r.CoreChampions
+		if champions == nil {
+			champions = []string{}
+		}
+
+		_, err = e.queries.UpsertConsolidatedTierEntry(ctx, generated.UpsertConsolidatedTierEntryParams{
+			Patch:             patch,
+			CompositionName:   r.Name,
+			ConsolidatedTier:  r.ConsolidatedTier,
+			ConsolidatedScore: floatToNumeric(r.ConsolidatedScore),
+			Confidence:        r.Confidence,
+			Consensus:         r.Consensus,
+			MetatftTier:       stringToText(r.MetaTFTTier),
+			TftacticsTier:     stringToText(r.TFTacticsTier),
+			MobalyticsTier:    stringToText(r.MobalyticsTier),
+			AvgWinRate:        floatToNumeric(r.AvgWinRate),
+			AvgPlayRate:       floatToNumeric(r.AvgPlayRate),
+			AvgPlacement:      floatToNumeric(r.AvgPlacement),
+			CoreChampions:     champions,
+			RecommendedItems:  itemsJSON,
+		})
+		if err != nil {
+			return fmt.Errorf("upsert consolidated %q: %w", r.Name, err)
+		}
+	}
+
+	log.Printf("consolidation: stored %d consolidated compositions for patch %s", len(results), patch)
+	return nil
+}
+
+func textToString(t pgtype.Text) string {
+	if !t.Valid {
+		return ""
+	}
+	return t.String
+}
+
+func numericToFloat(n pgtype.Numeric) float64 {
+	if !n.Valid || n.Int == nil {
+		return 0
+	}
+	f, _ := n.Float64Value()
+	return f.Float64
+}
+
+func stringToText(s string) pgtype.Text {
+	if s == "" {
+		return pgtype.Text{Valid: false}
+	}
+	return pgtype.Text{String: s, Valid: true}
+}
+
+func floatToNumeric(f float64) pgtype.Numeric {
+	if f == 0 {
+		return pgtype.Numeric{Valid: false}
+	}
+	scaled := int64(f * 100)
+	return pgtype.Numeric{
+		Int:   big.NewInt(scaled),
+		Exp:   -2,
+		Valid: true,
+	}
+}

--- a/backend/internal/consolidation/matcher.go
+++ b/backend/internal/consolidation/matcher.go
@@ -1,0 +1,113 @@
+package consolidation
+
+// JaccardSimilarity computes the Jaccard coefficient between two string slices.
+// Returns a value between 0.0 (no overlap) and 1.0 (identical).
+func JaccardSimilarity(a, b []string) float64 {
+	if len(a) == 0 && len(b) == 0 {
+		return 0
+	}
+
+	setA := make(map[string]struct{}, len(a))
+	for _, v := range a {
+		setA[v] = struct{}{}
+	}
+
+	setB := make(map[string]struct{}, len(b))
+	for _, v := range b {
+		setB[v] = struct{}{}
+	}
+
+	intersection := 0
+	for k := range setA {
+		if _, ok := setB[k]; ok {
+			intersection++
+		}
+	}
+
+	// Union = |A| + |B| - |A ∩ B|
+	union := len(setA) + len(setB) - intersection
+	if union == 0 {
+		return 0
+	}
+
+	return float64(intersection) / float64(union)
+}
+
+const matchThreshold = 0.8
+
+// MatchCompositions groups compositions from multiple sources by champion overlap.
+// Compositions with >= 80% Jaccard similarity are considered the same comp.
+func MatchCompositions(bySource map[string][]NormalizedComp) []MatchGroup {
+	var groups []MatchGroup
+
+	// Process each source in a deterministic order
+	sourceOrder := []string{"mobalytics", "tacticstools", "metatft"}
+
+	for _, source := range sourceOrder {
+		comps, ok := bySource[source]
+		if !ok {
+			continue
+		}
+
+		for _, comp := range comps {
+			bestIdx := -1
+			bestSim := 0.0
+
+			for i, group := range groups {
+				sim := JaccardSimilarity(comp.ChampionIDs, group.ChampionIDs)
+				if sim >= matchThreshold && sim > bestSim {
+					bestIdx = i
+					bestSim = sim
+				}
+			}
+
+			if bestIdx >= 0 {
+				// Add to existing group
+				groups[bestIdx].Sources = append(groups[bestIdx].Sources, comp)
+				// Merge champion IDs (union)
+				groups[bestIdx].ChampionIDs = unionStrings(groups[bestIdx].ChampionIDs, comp.ChampionIDs)
+				// Merge core items
+				for k, v := range comp.CoreItems {
+					if _, exists := groups[bestIdx].CoreItems[k]; !exists {
+						groups[bestIdx].CoreItems[k] = v
+					}
+				}
+			} else {
+				// Create new group
+				items := make(map[string][]string)
+				for k, v := range comp.CoreItems {
+					items[k] = v
+				}
+				groups = append(groups, MatchGroup{
+					Name:        comp.Name,
+					Sources:     []NormalizedComp{comp},
+					ChampionIDs: append([]string{}, comp.ChampionIDs...),
+					CoreItems:   items,
+				})
+			}
+		}
+	}
+
+	return groups
+}
+
+// unionStrings returns the union of two string slices with no duplicates.
+func unionStrings(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	var result []string
+
+	for _, v := range a {
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			result = append(result, v)
+		}
+	}
+	for _, v := range b {
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			result = append(result, v)
+		}
+	}
+
+	return result
+}

--- a/backend/internal/consolidation/scorer.go
+++ b/backend/internal/consolidation/scorer.go
@@ -1,0 +1,174 @@
+package consolidation
+
+import "math"
+
+// TierToScore converts a letter tier to a numeric score (0-100).
+var TierToScore = map[string]float64{
+	"S": 95,
+	"A": 80,
+	"B": 60,
+	"C": 40,
+	"D": 20,
+}
+
+// ScoreToTier converts a numeric score back to a letter tier.
+func ScoreToTier(score float64) string {
+	switch {
+	case score >= 88:
+		return "S"
+	case score >= 70:
+		return "A"
+	case score >= 50:
+		return "B"
+	case score >= 30:
+		return "C"
+	default:
+		return "D"
+	}
+}
+
+// DefaultWeights are the source weights for cross-ranking.
+var DefaultWeights = map[string]float64{
+	"mobalytics":   0.50,
+	"tacticstools": 0.35,
+	"metatft":      0.15,
+}
+
+// ScoreGroup computes the consolidated result for a match group.
+func ScoreGroup(group MatchGroup, weights map[string]float64) ConsolidatedResult {
+	if weights == nil {
+		weights = DefaultWeights
+	}
+
+	// Collect per-source data
+	tiers := make(map[string]string)       // source -> tier
+	scores := make(map[string]float64)     // source -> numeric score
+	winRates := make([]float64, 0)
+	playRates := make([]float64, 0)
+	placements := make([]float64, 0)
+
+	for _, src := range group.Sources {
+		tiers[src.Source] = src.Tier
+		scores[src.Source] = TierToScore[src.Tier]
+
+		if src.WinRate > 0 {
+			winRates = append(winRates, src.WinRate)
+		}
+		if src.PlayRate > 0 {
+			playRates = append(playRates, src.PlayRate)
+		}
+		if src.AvgPlacement > 0 {
+			placements = append(placements, src.AvgPlacement)
+		}
+	}
+
+	// Weighted score
+	totalWeight := 0.0
+	weightedScore := 0.0
+	for source, score := range scores {
+		w := weights[source]
+		if w == 0 {
+			w = 1.0 / float64(len(scores))
+		}
+		weightedScore += score * w
+		totalWeight += w
+	}
+	if totalWeight > 0 {
+		weightedScore /= totalWeight
+	}
+
+	// Confidence and consensus
+	confidence := computeConfidence(tiers)
+	consensus := computeConsensus(tiers)
+
+	return ConsolidatedResult{
+		Name:              group.Name,
+		ConsolidatedTier:  ScoreToTier(weightedScore),
+		ConsolidatedScore: math.Round(weightedScore*100) / 100,
+		Confidence:        confidence,
+		Consensus:         consensus,
+		MetaTFTTier:       tiers["metatft"],
+		TFTacticsTier:     tiers["tftactics"],
+		MobalyticsTier:    tiers["mobalytics"],
+		AvgWinRate:        avg(winRates),
+		AvgPlayRate:       avg(playRates),
+		AvgPlacement:      avg(placements),
+		CoreChampions:     group.ChampionIDs,
+		RecommendedItems:  group.CoreItems,
+	}
+}
+
+// computeConfidence determines confidence based on source agreement.
+func computeConfidence(tiers map[string]string) string {
+	if len(tiers) <= 1 {
+		return "low"
+	}
+
+	// Count how many sources agree within 1 tier
+	tierValues := make([]float64, 0, len(tiers))
+	for _, t := range tiers {
+		tierValues = append(tierValues, TierToScore[t])
+	}
+
+	// Check if all are within 20 points (1 tier difference)
+	allClose := true
+	for i := 0; i < len(tierValues); i++ {
+		for j := i + 1; j < len(tierValues); j++ {
+			if math.Abs(tierValues[i]-tierValues[j]) > 20 {
+				allClose = false
+			}
+		}
+	}
+
+	if allClose && len(tiers) >= 3 {
+		return "high"
+	}
+
+	// Check if majority (2/3) agree
+	tierCounts := make(map[string]int)
+	for _, t := range tiers {
+		tierCounts[t]++
+	}
+	for _, count := range tierCounts {
+		if count >= 2 {
+			return "medium"
+		}
+	}
+
+	return "low"
+}
+
+// computeConsensus determines the agreement level across sources.
+func computeConsensus(tiers map[string]string) string {
+	if len(tiers) <= 1 {
+		return "single_source"
+	}
+
+	tierCounts := make(map[string]int)
+	for _, t := range tiers {
+		tierCounts[t]++
+	}
+
+	if len(tierCounts) == 1 {
+		return "unanimous"
+	}
+
+	for _, count := range tierCounts {
+		if count >= 2 {
+			return "majority"
+		}
+	}
+
+	return "split"
+}
+
+func avg(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sum := 0.0
+	for _, v := range values {
+		sum += v
+	}
+	return math.Round(sum/float64(len(values))*100) / 100
+}

--- a/backend/internal/consolidation/types.go
+++ b/backend/internal/consolidation/types.go
@@ -1,0 +1,39 @@
+package consolidation
+
+// NormalizedComp represents a composition from one source after normalization.
+type NormalizedComp struct {
+	Source       string
+	Name         string
+	Tier         string
+	Score        float64
+	WinRate      float64
+	PlayRate     float64
+	AvgPlacement float64
+	ChampionIDs  []string
+	CoreItems    map[string][]string
+}
+
+// MatchGroup represents compositions from multiple sources that are the same comp.
+type MatchGroup struct {
+	Name         string            // canonical name (from first source found)
+	Sources      []NormalizedComp  // one per source (max 3)
+	ChampionIDs  []string          // union of all champion lists
+	CoreItems    map[string][]string
+}
+
+// ConsolidatedResult is the output of the scoring step for one composition.
+type ConsolidatedResult struct {
+	Name              string
+	ConsolidatedTier  string
+	ConsolidatedScore float64
+	Confidence        string
+	Consensus         string
+	MetaTFTTier       string
+	TFTacticsTier     string
+	MobalyticsTier    string
+	AvgWinRate        float64
+	AvgPlayRate       float64
+	AvgPlacement      float64
+	CoreChampions     []string
+	RecommendedItems  map[string][]string
+}

--- a/backend/internal/crawler/crawler.go
+++ b/backend/internal/crawler/crawler.go
@@ -1,0 +1,211 @@
+package crawler
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/sync/errgroup"
+)
+
+// Scraper defines the contract for a single-site scraper.
+type Scraper interface {
+	// Name returns the source identifier (e.g. "metatft").
+	Name() string
+	// Scrape fetches and parses tier list data from the source.
+	Scrape(ctx context.Context) (*ScrapeResult, error)
+}
+
+// OnCompleteFunc is called after a crawl cycle completes with the patch version.
+type OnCompleteFunc func(ctx context.Context, patch string) error
+
+// Crawler orchestrates multiple scrapers and stores results.
+type Crawler struct {
+	scrapers   []Scraper
+	store      *Store
+	interval   time.Duration
+	onComplete OnCompleteFunc
+
+	mu       sync.Mutex
+	statuses map[string]*SourceStatusInfo
+}
+
+// New creates a new Crawler.
+func New(db *pgxpool.Pool, scrapers []Scraper, interval time.Duration, onComplete OnCompleteFunc) *Crawler {
+	statuses := make(map[string]*SourceStatusInfo, len(scrapers))
+	for _, s := range scrapers {
+		statuses[s.Name()] = &SourceStatusInfo{
+			Source: s.Name(),
+			Status: "never",
+		}
+	}
+
+	return &Crawler{
+		scrapers:   scrapers,
+		store:      NewStore(db),
+		interval:   interval,
+		onComplete: onComplete,
+		statuses:   statuses,
+	}
+}
+
+// Run executes a single crawl cycle: scrapes all sources in parallel, stores results,
+// then triggers consolidation.
+func (c *Crawler) Run(ctx context.Context) error {
+	log.Println("crawler: starting crawl cycle...")
+	start := time.Now()
+
+	type result struct {
+		scrapeResult *ScrapeResult
+		err          error
+		name         string
+	}
+
+	results := make([]result, len(c.scrapers))
+	g, gCtx := errgroup.WithContext(ctx)
+
+	for i, scraper := range c.scrapers {
+		g.Go(func() error {
+			log.Printf("crawler: scraping %s...", scraper.Name())
+			sr, err := scraper.Scrape(gCtx)
+			results[i] = result{scrapeResult: sr, err: err, name: scraper.Name()}
+			// Don't propagate errors — one failure shouldn't block others
+			return nil
+		})
+	}
+
+	_ = g.Wait()
+
+	// Process results
+	var (
+		successCount int
+		lastPatch    string
+	)
+
+	for _, r := range results {
+		c.mu.Lock()
+		status := c.statuses[r.name]
+
+		if r.err != nil {
+			log.Printf("crawler: %s failed: %v", r.name, r.err)
+			status.Status = "error"
+			status.ErrorMessage = r.err.Error()
+			c.mu.Unlock()
+			continue
+		}
+
+		// Store the scraped data
+		if err := c.store.SaveResult(ctx, r.scrapeResult); err != nil {
+			log.Printf("crawler: failed to store %s results: %v", r.name, err)
+			status.Status = "error"
+			status.ErrorMessage = fmt.Sprintf("store failed: %v", err)
+			c.mu.Unlock()
+			continue
+		}
+
+		status.Status = "ok"
+		status.LastScraped = r.scrapeResult.ScrapedAt
+		status.ErrorMessage = ""
+		c.mu.Unlock()
+
+		successCount++
+		if r.scrapeResult.Patch != "" && r.scrapeResult.Patch != "unknown" {
+			lastPatch = r.scrapeResult.Patch
+		} else if lastPatch == "" {
+			lastPatch = r.scrapeResult.Patch
+		}
+	}
+
+	// Normalize patches — use the best known patch for all "unknown" results
+	if lastPatch != "" && lastPatch != "unknown" {
+		for _, r := range results {
+			if r.scrapeResult != nil && (r.scrapeResult.Patch == "" || r.scrapeResult.Patch == "unknown") {
+				r.scrapeResult.Patch = lastPatch
+				// Re-store with correct patch
+				_ = c.store.SaveResult(ctx, r.scrapeResult)
+			}
+		}
+	}
+
+	log.Printf("crawler: cycle complete — %d/%d sources succeeded (%v)",
+		successCount, len(c.scrapers), time.Since(start))
+
+	// Trigger consolidation if we have any data
+	if successCount > 0 && lastPatch != "" && c.onComplete != nil {
+		log.Printf("crawler: triggering consolidation for patch %s...", lastPatch)
+		if err := c.onComplete(ctx, lastPatch); err != nil {
+			log.Printf("crawler: consolidation failed: %v", err)
+			return fmt.Errorf("consolidation: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// StartScheduler runs the crawler on a periodic schedule.
+// It blocks until the context is cancelled.
+func (c *Crawler) StartScheduler(ctx context.Context) {
+	log.Printf("crawler: scheduler started (interval: %v)", c.interval)
+
+	// Run immediately on first start if data is stale
+	if c.shouldRunNow(ctx) {
+		if err := c.Run(ctx); err != nil {
+			log.Printf("crawler: initial run failed: %v", err)
+		}
+	}
+
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("crawler: scheduler stopped")
+			return
+		case <-ticker.C:
+			if err := c.Run(ctx); err != nil {
+				log.Printf("crawler: scheduled run failed: %v", err)
+			}
+		}
+	}
+}
+
+// shouldRunNow checks if the last scrape is older than the interval.
+func (c *Crawler) shouldRunNow(ctx context.Context) bool {
+	latest, err := c.store.queries.GetLatestScrapedAt(ctx)
+	if err != nil || latest == nil {
+		return true // No data yet
+	}
+
+	if t, ok := latest.(time.Time); ok {
+		return time.Since(t) > c.interval
+	}
+	return true
+}
+
+// GetStatuses returns the current scraper statuses.
+func (c *Crawler) GetStatuses() []SourceStatusInfo {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	out := make([]SourceStatusInfo, 0, len(c.statuses))
+	for _, s := range c.statuses {
+		out = append(out, *s)
+	}
+	return out
+}
+
+// --- Shared helpers ---
+
+// normalizeTier converts tier strings to a consistent uppercase format.
+func normalizeTier(tier string) string {
+	t := strings.ToUpper(strings.TrimSpace(tier))
+	if t == "S+" {
+		return "S"
+	}
+	return t
+}

--- a/backend/internal/crawler/httpclient.go
+++ b/backend/internal/crawler/httpclient.go
@@ -1,0 +1,161 @@
+package crawler
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+const (
+	maxRetries     = 3
+	baseRetryDelay = 1 * time.Second
+	maxRetryDelay  = 10 * time.Second
+	defaultTimeout = 30 * time.Second
+	userAgent      = "TFTOracle/1.0 (https://github.com/MeninoNias/tft-oracle)"
+)
+
+// HTTPClient is a shared HTTP client with retry and rate limiting for web scraping.
+type HTTPClient struct {
+	http    *http.Client
+	limiter *rate.Limiter
+	baseURL string // override for tests
+}
+
+// NewHTTPClient creates a scraping HTTP client.
+func NewHTTPClient() *HTTPClient {
+	return &HTTPClient{
+		http: &http.Client{
+			Timeout: defaultTimeout,
+		},
+		// Conservative: 1 request per second per scraper
+		limiter: rate.NewLimiter(rate.Every(time.Second), 1),
+	}
+}
+
+// Get fetches a URL with rate limiting, retry logic, and proper headers.
+func (c *HTTPClient) Get(ctx context.Context, rawURL string) ([]byte, error) {
+	if c.baseURL != "" {
+		rawURL = c.baseURL + rawURL
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if err := c.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("rate limiter: %w", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("User-Agent", userAgent)
+		req.Header.Set("Accept", "text/html,application/json")
+
+		resp, err := c.http.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("http request: %w", err)
+			if attempt < maxRetries {
+				sleepWithContext(ctx, retryDelay(attempt))
+				continue
+			}
+			return nil, lastErr
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read response body: %w", err)
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			return body, nil
+		}
+
+		lastErr = fmt.Errorf("http %d: %s", resp.StatusCode, truncate(string(body), 200))
+
+		// Retry on server errors and rate limits
+		if (resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests) && attempt < maxRetries {
+			sleepWithContext(ctx, retryDelay(attempt))
+			continue
+		}
+
+		return nil, lastErr
+	}
+	return nil, lastErr
+}
+
+func retryDelay(attempt int) time.Duration {
+	d := baseRetryDelay * (1 << uint(attempt))
+	if d > maxRetryDelay {
+		return maxRetryDelay
+	}
+	return d
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) {
+	select {
+	case <-time.After(d):
+	case <-ctx.Done():
+	}
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
+// Post sends a POST request with JSON body (needed for GraphQL endpoints).
+func (c *HTTPClient) Post(ctx context.Context, rawURL string, body []byte) ([]byte, error) {
+	if c.baseURL != "" {
+		rawURL = c.baseURL + rawURL
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if err := c.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("rate limiter: %w", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", userAgent)
+
+		resp, err := c.http.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("http request: %w", err)
+			if attempt < maxRetries {
+				sleepWithContext(ctx, retryDelay(attempt))
+				continue
+			}
+			return nil, lastErr
+		}
+
+		respBody, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read response body: %w", err)
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			return respBody, nil
+		}
+
+		lastErr = fmt.Errorf("http %d: %s", resp.StatusCode, truncate(string(respBody), 200))
+		if (resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests) && attempt < maxRetries {
+			sleepWithContext(ctx, retryDelay(attempt))
+			continue
+		}
+		return nil, lastErr
+	}
+	return nil, lastErr
+}

--- a/backend/internal/crawler/metatft.go
+++ b/backend/internal/crawler/metatft.go
@@ -1,0 +1,26 @@
+package crawler
+
+import (
+	"context"
+	"fmt"
+)
+
+const metatftSource = "metatft"
+
+// MetaTFTScraper is a placeholder for MetaTFT scraping.
+// MetaTFT is a client-side SPA with no public API — scraping requires
+// a headless browser (Puppeteer/Chromedp), which is planned for a future iteration.
+type MetaTFTScraper struct {
+	client *HTTPClient
+}
+
+// NewMetaTFTScraper creates a MetaTFT scraper.
+func NewMetaTFTScraper(client *HTTPClient) *MetaTFTScraper {
+	return &MetaTFTScraper{client: client}
+}
+
+func (s *MetaTFTScraper) Name() string { return metatftSource }
+
+func (s *MetaTFTScraper) Scrape(ctx context.Context) (*ScrapeResult, error) {
+	return nil, fmt.Errorf("metatft scraper not yet implemented — requires headless browser")
+}

--- a/backend/internal/crawler/mobalytics.go
+++ b/backend/internal/crawler/mobalytics.go
@@ -1,0 +1,187 @@
+package crawler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	mobalyticsSource     = "mobalytics"
+	mobalyticsGraphQLURL = "https://mobalytics.gg/api/tft/v1/graphql/query"
+)
+
+// MobalyticsScraper scrapes composition tier data from Mobalytics via GraphQL.
+type MobalyticsScraper struct {
+	client *HTTPClient
+}
+
+// NewMobalyticsScraper creates a Mobalytics scraper.
+func NewMobalyticsScraper(client *HTTPClient) *MobalyticsScraper {
+	return &MobalyticsScraper{client: client}
+}
+
+func (s *MobalyticsScraper) Name() string { return mobalyticsSource }
+
+func (s *MobalyticsScraper) Scrape(ctx context.Context) (*ScrapeResult, error) {
+	var allComps []RawComposition
+	var patch string
+
+	for _, tier := range []string{"s", "a", "b", "c"} {
+		comps, p, err := s.scrapeTier(ctx, tier)
+		if err != nil {
+			return nil, fmt.Errorf("scrape tier %s: %w", tier, err)
+		}
+		allComps = append(allComps, comps...)
+		if p != "" {
+			patch = p
+		}
+	}
+
+	if len(allComps) == 0 {
+		return nil, fmt.Errorf("mobalytics returned 0 compositions")
+	}
+
+	return &ScrapeResult{
+		Source:       mobalyticsSource,
+		Patch:        patch,
+		Compositions: allComps,
+		ScrapedAt:    time.Now(),
+	}, nil
+}
+
+func (s *MobalyticsScraper) scrapeTier(ctx context.Context, tier string) ([]RawComposition, string, error) {
+	query := `{
+		tft {
+			metaCompositions(filter: {set: "16", tier: "` + tier + `"}, first: 50) {
+				items {
+					name
+					tier
+					patch
+					slug
+					formation {
+						positions {
+							champion {
+								champion { slug }
+								items { slug }
+								level
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	body, err := json.Marshal(map[string]string{"query": query})
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal query: %w", err)
+	}
+
+	respBody, err := s.client.Post(ctx, mobalyticsGraphQLURL, body)
+	if err != nil {
+		return nil, "", fmt.Errorf("graphql request: %w", err)
+	}
+
+	var resp mobalyticsGQLResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, "", fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	items := resp.Data.TFT.MetaCompositions.Items
+	if len(items) == 0 {
+		return nil, "", nil
+	}
+
+	patch := items[0].Patch
+	comps := make([]RawComposition, 0, len(items))
+
+	for _, item := range items {
+		champIDs := make([]string, 0)
+		coreItems := make(map[string][]string)
+
+		for _, pos := range item.Formation.Positions {
+			slug := pos.Champion.Champion.Slug
+			apiName := slugToApiName(slug)
+			champIDs = append(champIDs, apiName)
+
+			if len(pos.Champion.Items) > 0 {
+				itemSlugs := make([]string, 0, len(pos.Champion.Items))
+				for _, it := range pos.Champion.Items {
+					itemSlugs = append(itemSlugs, it.Slug)
+				}
+				coreItems[apiName] = itemSlugs
+			}
+		}
+
+		comps = append(comps, RawComposition{
+			Name:        item.Name,
+			Tier:        normalizeTier(item.Tier),
+			ChampionIDs: champIDs,
+			CoreItems:   coreItems,
+		})
+	}
+
+	return comps, patch, nil
+}
+
+// slugToApiName converts Mobalytics slug to Riot api_name format.
+func slugToApiName(slug string) string {
+	known := map[string]string{
+		"kogmaw":      "TFT16_KogMaw",
+		"missfortune": "TFT16_MissFortune",
+		"luciansenna": "TFT16_LucianSenna",
+		"kobukoyuumi": "TFT16_KobukoYuumi",
+		"baronnashor": "TFT16_BaronNashor",
+		"riftherald":  "TFT16_RiftHerald",
+		"drmundo":     "TFT16_DrMundo",
+		"reksai":      "TFT16_RekSai",
+		"tahmkench":   "TFT16_TahmKench",
+		"chogath":     "TFT16_ChoGath",
+	}
+
+	if name, ok := known[slug]; ok {
+		return name
+	}
+
+	if len(slug) == 0 {
+		return slug
+	}
+	return "TFT16_" + strings.ToUpper(slug[:1]) + slug[1:]
+}
+
+// --- GraphQL response types ---
+
+type mobalyticsGQLResponse struct {
+	Data struct {
+		TFT struct {
+			MetaCompositions struct {
+				Items []mobalyticsCompItem `json:"items"`
+			} `json:"metaCompositions"`
+		} `json:"tft"`
+	} `json:"data"`
+}
+
+type mobalyticsCompItem struct {
+	Name      string `json:"name"`
+	Tier      string `json:"tier"`
+	Patch     string `json:"patch"`
+	Slug      string `json:"slug"`
+	Formation struct {
+		Positions []mobalyticsPosition `json:"positions"`
+	} `json:"formation"`
+}
+
+type mobalyticsPosition struct {
+	Champion struct {
+		Champion struct {
+			Slug string `json:"slug"`
+		} `json:"champion"`
+		Items []struct {
+			Slug string `json:"slug"`
+		} `json:"items"`
+		Level int `json:"level"`
+	} `json:"champion"`
+}

--- a/backend/internal/crawler/store.go
+++ b/backend/internal/crawler/store.go
@@ -1,0 +1,105 @@
+package crawler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/big"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/MeninoNias/tft-oracle/backend/sqlc/generated"
+)
+
+// Store handles persisting raw tier data to the database.
+type Store struct {
+	db      *pgxpool.Pool
+	queries *generated.Queries
+}
+
+// NewStore creates a new crawler store.
+func NewStore(db *pgxpool.Pool) *Store {
+	return &Store{
+		db:      db,
+		queries: generated.New(db),
+	}
+}
+
+// SaveResult persists a scrape result to the database.
+// It deletes old data for the source+patch and inserts new rows in a single transaction.
+func (s *Store) SaveResult(ctx context.Context, result *ScrapeResult) error {
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	qtx := s.queries.WithTx(tx)
+
+	// Delete old data for this source+patch
+	if err := qtx.DeleteRawTierDataBySourceAndPatch(ctx, generated.DeleteRawTierDataBySourceAndPatchParams{
+		Source: result.Source,
+		Patch:  result.Patch,
+	}); err != nil {
+		return fmt.Errorf("delete old data: %w", err)
+	}
+
+	// Insert new compositions
+	for _, comp := range result.Compositions {
+		coreItemsJSON, err := json.Marshal(comp.CoreItems)
+		if err != nil {
+			return fmt.Errorf("marshal core items: %w", err)
+		}
+
+		championIDs := comp.ChampionIDs
+		if championIDs == nil {
+			championIDs = []string{}
+		}
+
+		_, err = qtx.InsertRawTierData(ctx, generated.InsertRawTierDataParams{
+			Source:          result.Source,
+			Patch:           result.Patch,
+			CompositionName: comp.Name,
+			Tier:            textFromString(comp.Tier),
+			WinRate:         numericFromFloat(comp.WinRate),
+			PlayRate:        numericFromFloat(comp.PlayRate),
+			AvgPlacement:    numericFromFloat(comp.AvgPlacement),
+			ChampionIds:     championIDs,
+			CoreItems:       coreItemsJSON,
+		})
+		if err != nil {
+			return fmt.Errorf("insert comp %q: %w", comp.Name, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
+	}
+
+	log.Printf("crawler: stored %d compositions from %s (patch %s)",
+		len(result.Compositions), result.Source, result.Patch)
+	return nil
+}
+
+func textFromString(s string) pgtype.Text {
+	if s == "" {
+		return pgtype.Text{Valid: false}
+	}
+	return pgtype.Text{String: s, Valid: true}
+}
+
+func numericFromFloat(f float64) pgtype.Numeric {
+	if f == 0 {
+		return pgtype.Numeric{Valid: false}
+	}
+	// Convert float to *big.Int with 2 decimal places
+	scaled := int64(f * 100)
+	return pgtype.Numeric{
+		Int:   big.NewInt(scaled),
+		Exp:   -2,
+		Valid: true,
+	}
+}

--- a/backend/internal/crawler/tftactics.go
+++ b/backend/internal/crawler/tftactics.go
@@ -1,0 +1,197 @@
+package crawler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"time"
+)
+
+const (
+	tacticsToolsSource = "tacticstools"
+	tacticsToolsURL    = "https://tactics.tools/team-compositions"
+)
+
+// TacticsToolsScraper scrapes composition data from tactics.tools via __NEXT_DATA__.
+type TacticsToolsScraper struct {
+	client *HTTPClient
+}
+
+// NewTacticsToolsScraper creates a tactics.tools scraper.
+func NewTacticsToolsScraper(client *HTTPClient) *TacticsToolsScraper {
+	return &TacticsToolsScraper{client: client}
+}
+
+func (s *TacticsToolsScraper) Name() string { return tacticsToolsSource }
+
+func (s *TacticsToolsScraper) Scrape(ctx context.Context) (*ScrapeResult, error) {
+	body, err := s.client.Get(ctx, tacticsToolsURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetch tactics.tools: %w", err)
+	}
+
+	comps, patch, err := parseTacticsToolsHTML(body)
+	if err != nil {
+		return nil, fmt.Errorf("parse tactics.tools: %w", err)
+	}
+
+	if len(comps) == 0 {
+		return nil, fmt.Errorf("tactics.tools returned 0 compositions")
+	}
+
+	return &ScrapeResult{
+		Source:       tacticsToolsSource,
+		Patch:        patch,
+		Compositions: comps,
+		ScrapedAt:    time.Now(),
+	}, nil
+}
+
+var nextDataRe = regexp.MustCompile(`<script id="__NEXT_DATA__" type="application/json">(.*?)</script>`)
+
+func parseTacticsToolsHTML(html []byte) ([]RawComposition, string, error) {
+	matches := nextDataRe.FindSubmatch(html)
+	if len(matches) < 2 {
+		return nil, "", fmt.Errorf("__NEXT_DATA__ not found in HTML")
+	}
+
+	var nextData tacticsToolsNextData
+	if err := json.Unmarshal(matches[1], &nextData); err != nil {
+		return nil, "", fmt.Errorf("unmarshal __NEXT_DATA__: %w", err)
+	}
+
+	data := nextData.Props.PageProps.InitialData
+	if data == nil {
+		return nil, "", fmt.Errorf("no initialData in page props")
+	}
+
+	// Determine patch from aperture
+	patch := "unknown"
+
+	// Process compositions from nonSpatComps (main comp list)
+	rawComps := data.NonSpatComps
+	if len(rawComps) == 0 && len(data.Groups) > 0 {
+		// Fall back to groups
+		for _, g := range data.Groups {
+			rawComps = append(rawComps, g.Full.Comps...)
+		}
+	}
+
+	comps := make([]RawComposition, 0, len(rawComps))
+	for _, rc := range rawComps {
+		if len(rc.Units) == 0 {
+			continue
+		}
+
+		// Validate data
+		if rc.Place < 1 || rc.Place > 8 {
+			continue
+		}
+
+		// Calculate win rate and play rate
+		winRate := 0.0
+		if rc.Count > 0 {
+			winRate = float64(rc.Win) / float64(rc.Count) * 100
+		}
+
+		top4Rate := 0.0
+		if rc.Count > 0 {
+			top4Rate = float64(rc.Top4) / float64(rc.Count) * 100
+		}
+
+		// Assign tier based on average placement
+		tier := placementToTier(rc.Place)
+
+		// Name from champion list (no names in data)
+		name := buildCompName(rc.Units)
+
+		comps = append(comps, RawComposition{
+			Name:         name,
+			Tier:         tier,
+			WinRate:      winRate,
+			PlayRate:     top4Rate, // Using top4 rate as "play rate" metric
+			AvgPlacement: rc.Place,
+			ChampionIDs:  rc.Units,
+			CoreItems:    make(map[string][]string),
+		})
+	}
+
+	return comps, patch, nil
+}
+
+// placementToTier maps average placement to a tier letter.
+func placementToTier(avgPlace float64) string {
+	switch {
+	case avgPlace <= 3.2:
+		return "S"
+	case avgPlace <= 3.8:
+		return "A"
+	case avgPlace <= 4.3:
+		return "B"
+	default:
+		return "C"
+	}
+}
+
+// buildCompName creates a human-readable name from champion IDs.
+func buildCompName(units []string) string {
+	if len(units) == 0 {
+		return "Unknown"
+	}
+	// Take first 2-3 champs, strip the TFT16_ prefix
+	names := make([]string, 0, 3)
+	for i, u := range units {
+		if i >= 3 {
+			break
+		}
+		name := u
+		if idx := len("TFT16_"); len(u) > idx && u[:idx] == "TFT16_" {
+			name = u[idx:]
+		}
+		names = append(names, name)
+	}
+	result := ""
+	for i, n := range names {
+		if i > 0 {
+			result += " "
+		}
+		result += n
+	}
+	return result
+}
+
+// --- __NEXT_DATA__ response types ---
+
+type tacticsToolsNextData struct {
+	Props struct {
+		PageProps struct {
+			InitialData *tacticsToolsData `json:"initialData"`
+		} `json:"pageProps"`
+	} `json:"props"`
+}
+
+type tacticsToolsData struct {
+	Count        int                    `json:"count"`
+	Place        float64                `json:"place"`
+	Top4         int                    `json:"top4"`
+	Win          int                    `json:"win"`
+	NonSpatComps []tacticsToolsComp     `json:"nonSpatComps"`
+	Groups       []tacticsToolsGroup    `json:"groups"`
+}
+
+type tacticsToolsGroup struct {
+	Full struct {
+		Comps []tacticsToolsComp `json:"comps"`
+	} `json:"full"`
+}
+
+type tacticsToolsComp struct {
+	Units       []string `json:"units"`
+	SpatItems   []string `json:"spatItems"`
+	ExtraTraits []string `json:"extraTraits"`
+	Count       int      `json:"count"`
+	Place       float64  `json:"place"`
+	Top4        int      `json:"top4"`
+	Win         int      `json:"win"`
+}

--- a/backend/internal/crawler/types.go
+++ b/backend/internal/crawler/types.go
@@ -1,0 +1,30 @@
+package crawler
+
+import "time"
+
+// RawComposition represents a single composition scraped from a tier list site.
+type RawComposition struct {
+	Name         string            `json:"name"`
+	Tier         string            `json:"tier"`
+	WinRate      float64           `json:"win_rate"`
+	PlayRate     float64           `json:"play_rate"`
+	AvgPlacement float64           `json:"avg_placement"`
+	ChampionIDs  []string          `json:"champion_ids"`  // api_names
+	CoreItems    map[string][]string `json:"core_items"`   // champion_api_name -> [item_api_names]
+}
+
+// ScrapeResult holds the output of a single scrape operation.
+type ScrapeResult struct {
+	Source       string           `json:"source"`
+	Patch        string           `json:"patch"`
+	Compositions []RawComposition `json:"compositions"`
+	ScrapedAt    time.Time        `json:"scraped_at"`
+}
+
+// SourceStatusInfo tracks the health of each scraper.
+type SourceStatusInfo struct {
+	Source       string
+	LastScraped  time.Time
+	Status       string // "ok", "error", "never"
+	ErrorMessage string
+}

--- a/backend/internal/tierlist/mapper.go
+++ b/backend/internal/tierlist/mapper.go
@@ -1,0 +1,57 @@
+package tierlist
+
+import (
+	"encoding/json"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	tftv1 "github.com/MeninoNias/tft-oracle/backend/gen/tft/v1"
+	"github.com/MeninoNias/tft-oracle/backend/sqlc/generated"
+)
+
+func mapToProto(row generated.ConsolidatedTierList) *tftv1.TierListEntry {
+	entry := &tftv1.TierListEntry{
+		CompositionName:   row.CompositionName,
+		ConsolidatedTier:  row.ConsolidatedTier,
+		ConsolidatedScore: numericToFloat64(row.ConsolidatedScore),
+		Confidence:        row.Confidence,
+		Consensus:         row.Consensus,
+		MetatftTier:       textToString(row.MetatftTier),
+		TftacticsTier:     textToString(row.TftacticsTier),
+		MobalyticsTier:    textToString(row.MobalyticsTier),
+		AvgWinRate:        numericToFloat64(row.AvgWinRate),
+		AvgPlayRate:       numericToFloat64(row.AvgPlayRate),
+		AvgPlacement:      numericToFloat64(row.AvgPlacement),
+		CoreChampions:     row.CoreChampions,
+	}
+
+	// Parse recommended items from JSONB
+	if len(row.RecommendedItems) > 0 {
+		var items map[string][]string
+		if err := json.Unmarshal(row.RecommendedItems, &items); err == nil {
+			entry.RecommendedItems = make(map[string]*tftv1.ItemList, len(items))
+			for champ, itemList := range items {
+				entry.RecommendedItems[champ] = &tftv1.ItemList{
+					ItemApiNames: itemList,
+				}
+			}
+		}
+	}
+
+	return entry
+}
+
+func textToString(t pgtype.Text) string {
+	if !t.Valid {
+		return ""
+	}
+	return t.String
+}
+
+func numericToFloat64(n pgtype.Numeric) float64 {
+	if !n.Valid || n.Int == nil {
+		return 0
+	}
+	f, _ := n.Float64Value()
+	return f.Float64
+}

--- a/backend/internal/tierlist/service.go
+++ b/backend/internal/tierlist/service.go
@@ -1,0 +1,128 @@
+package tierlist
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"connectrpc.com/connect"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	tftv1 "github.com/MeninoNias/tft-oracle/backend/gen/tft/v1"
+	"github.com/MeninoNias/tft-oracle/backend/gen/tft/v1/tftv1connect"
+	"github.com/MeninoNias/tft-oracle/backend/internal/crawler"
+	"github.com/MeninoNias/tft-oracle/backend/sqlc/generated"
+)
+
+var _ tftv1connect.TierListServiceHandler = (*Service)(nil)
+
+// Service handles tier list RPCs.
+type Service struct {
+	db      *pgxpool.Pool
+	queries *generated.Queries
+	crawler *crawler.Crawler
+}
+
+// NewService creates a new TierList service.
+func NewService(db *pgxpool.Pool, c *crawler.Crawler) *Service {
+	return &Service{
+		db:      db,
+		queries: generated.New(db),
+		crawler: c,
+	}
+}
+
+func (s *Service) GetConsolidatedTierList(
+	ctx context.Context,
+	req *connect.Request[tftv1.GetConsolidatedTierListRequest],
+) (*connect.Response[tftv1.GetConsolidatedTierListResponse], error) {
+	patch := req.Msg.Patch
+	tierFilter := req.Msg.TierFilter
+
+	// If no patch specified, use latest available
+	if patch == "" {
+		latestPatch, err := s.queries.GetLatestConsolidatedPatch(ctx)
+		if err == nil {
+			patch = latestPatch
+		}
+	}
+
+	var rows []generated.ConsolidatedTierList
+	var err error
+
+	if tierFilter != "" {
+		rows, err = s.queries.GetConsolidatedTierListByTier(ctx, generated.GetConsolidatedTierListByTierParams{
+			Patch:            patch,
+			ConsolidatedTier: tierFilter,
+		})
+	} else {
+		rows, err = s.queries.GetConsolidatedTierList(ctx, patch)
+	}
+
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("query tier list: %w", err))
+	}
+
+	entries := make([]*tftv1.TierListEntry, 0, len(rows))
+	for _, row := range rows {
+		entries = append(entries, mapToProto(row))
+	}
+
+	// Determine last_updated from the most recent entry
+	lastUpdated := ""
+	if len(rows) > 0 && rows[0].UpdatedAt.Valid {
+		lastUpdated = rows[0].UpdatedAt.Time.Format("2006-01-02T15:04:05Z")
+	}
+
+	return connect.NewResponse(&tftv1.GetConsolidatedTierListResponse{
+		Patch:       patch,
+		Entries:     entries,
+		LastUpdated: lastUpdated,
+	}), nil
+}
+
+func (s *Service) TriggerCrawl(
+	ctx context.Context,
+	req *connect.Request[tftv1.TriggerCrawlRequest],
+) (*connect.Response[tftv1.TriggerCrawlResponse], error) {
+	if s.crawler == nil {
+		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("crawler not configured"))
+	}
+
+	// Run crawl in a goroutine to not block the RPC
+	go func() {
+		bgCtx := context.Background()
+		if err := s.crawler.Run(bgCtx); err != nil {
+			log.Printf("tierlist: triggered crawl failed: %v", err)
+		}
+	}()
+
+	return connect.NewResponse(&tftv1.TriggerCrawlResponse{
+		Message: "crawl triggered",
+	}), nil
+}
+
+func (s *Service) GetCrawlerStatus(
+	ctx context.Context,
+	req *connect.Request[tftv1.GetCrawlerStatusRequest],
+) (*connect.Response[tftv1.GetCrawlerStatusResponse], error) {
+	resp := &tftv1.GetCrawlerStatusResponse{}
+
+	if s.crawler != nil {
+		statuses := s.crawler.GetStatuses()
+		for _, st := range statuses {
+			lastScraped := ""
+			if !st.LastScraped.IsZero() {
+				lastScraped = st.LastScraped.Format("2006-01-02T15:04:05Z")
+			}
+			resp.Sources = append(resp.Sources, &tftv1.SourceStatus{
+				Source:       st.Source,
+				LastScraped:  lastScraped,
+				Status:       st.Status,
+				ErrorMessage: st.ErrorMessage,
+			})
+		}
+	}
+
+	return connect.NewResponse(resp), nil
+}

--- a/backend/sqlc/queries/consolidated_tier_list.sql
+++ b/backend/sqlc/queries/consolidated_tier_list.sql
@@ -1,0 +1,44 @@
+-- name: UpsertConsolidatedTierEntry :one
+INSERT INTO consolidated_tier_list (
+    patch, composition_name, consolidated_tier, consolidated_score,
+    confidence, consensus,
+    metatft_tier, tftactics_tier, mobalytics_tier,
+    avg_win_rate, avg_play_rate, avg_placement,
+    core_champions, recommended_items, updated_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NOW()
+)
+ON CONFLICT (patch, composition_name) DO UPDATE SET
+    consolidated_tier  = EXCLUDED.consolidated_tier,
+    consolidated_score = EXCLUDED.consolidated_score,
+    confidence         = EXCLUDED.confidence,
+    consensus          = EXCLUDED.consensus,
+    metatft_tier       = EXCLUDED.metatft_tier,
+    tftactics_tier     = EXCLUDED.tftactics_tier,
+    mobalytics_tier    = EXCLUDED.mobalytics_tier,
+    avg_win_rate       = EXCLUDED.avg_win_rate,
+    avg_play_rate      = EXCLUDED.avg_play_rate,
+    avg_placement      = EXCLUDED.avg_placement,
+    core_champions     = EXCLUDED.core_champions,
+    recommended_items  = EXCLUDED.recommended_items,
+    updated_at         = NOW()
+RETURNING *;
+
+-- name: GetConsolidatedTierList :many
+SELECT * FROM consolidated_tier_list
+WHERE patch = $1
+ORDER BY consolidated_score DESC;
+
+-- name: GetConsolidatedTierListByTier :many
+SELECT * FROM consolidated_tier_list
+WHERE patch = $1 AND consolidated_tier = $2
+ORDER BY consolidated_score DESC;
+
+-- name: DeleteConsolidatedByPatch :exec
+DELETE FROM consolidated_tier_list
+WHERE patch = $1;
+
+-- name: GetLatestConsolidatedPatch :one
+SELECT patch FROM consolidated_tier_list
+ORDER BY updated_at DESC
+LIMIT 1;

--- a/backend/sqlc/queries/raw_tier_data.sql
+++ b/backend/sqlc/queries/raw_tier_data.sql
@@ -1,0 +1,26 @@
+-- name: InsertRawTierData :one
+INSERT INTO raw_tier_data (
+    source, patch, composition_name, tier,
+    win_rate, play_rate, avg_placement,
+    champion_ids, core_items, scraped_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, NOW()
+)
+RETURNING *;
+
+-- name: GetRawTierDataByPatch :many
+SELECT * FROM raw_tier_data
+WHERE patch = $1
+ORDER BY source, tier, composition_name;
+
+-- name: GetRawTierDataBySourceAndPatch :many
+SELECT * FROM raw_tier_data
+WHERE source = $1 AND patch = $2
+ORDER BY tier, composition_name;
+
+-- name: DeleteRawTierDataBySourceAndPatch :exec
+DELETE FROM raw_tier_data
+WHERE source = $1 AND patch = $2;
+
+-- name: GetLatestScrapedAt :one
+SELECT MAX(scraped_at) FROM raw_tier_data;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { UnauthorizedPage } from "@/pages/unauthorized";
 import { AugmentsPage } from "@/pages/augments";
 import { SettingsPage } from "@/pages/settings";
 import { SimulatorPage } from "@/pages/simulator";
+import { TierListPage } from "@/pages/tier-list";
 import { SplashScreen } from "@/components/splash-screen";
 import { useTheme } from "@/hooks/use-theme";
 
@@ -48,6 +49,7 @@ export function App() {
               <Route path="/items" element={<ItemsPage />} />
               <Route path="/augments" element={<AugmentsPage />} />
               <Route path="/simulator" element={<SimulatorPage />} />
+              <Route path="/tier-list" element={<TierListPage />} />
               <Route path="/profile" element={<ProfilePage />} />
               <Route path="/player" element={<PlayerPage />} />
               <Route path="/settings" element={<SettingsPage />} />

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -6,6 +6,7 @@ const navItems = [
   { to: "/items", label: "items" },
   { to: "/augments", label: "augments" },
   { to: "/simulator", label: "simulator" },
+  { to: "/tier-list", label: "tier list" },
   { to: "/profile", label: "profile" },
   { to: "/player", label: "player search" },
   { to: "/settings", label: "settings" },
@@ -22,7 +23,7 @@ export function Sidebar() {
           TFT_ORACLE
         </h1>
         <p className="mt-0.5 text-[10px] text-lofi-muted">
-          v0.2.0 // phase 2
+          v0.4.0 // phase 4
         </p>
       </div>
 
@@ -79,7 +80,7 @@ export function Sidebar() {
 
       <div className="border-t border-lofi-border px-4 py-3">
         <p className="text-[10px] text-lofi-muted">
-          data: communitydragon + riot api
+          data: communitydragon + riot api + metatft + tftactics + mobalytics
         </p>
       </div>
     </aside>

--- a/frontend/src/components/tier-list/composition-card.tsx
+++ b/frontend/src/components/tier-list/composition-card.tsx
@@ -1,0 +1,132 @@
+import { TerminalCard } from "@/components/ui/terminal-card";
+import { Badge } from "@/components/ui/badge";
+import { ConfidenceIndicator } from "./confidence-indicator";
+import { SourceBreakdown } from "./source-breakdown";
+import type { TierListEntry } from "@/gen/tft/v1/tierlist_pb";
+import type { Champion, Item } from "@/gen/tft/v1/patch_pb";
+
+const consensusStyles: Record<string, string> = {
+  unanimous: "border-green-500/30 bg-green-500/10 text-green-400",
+  majority: "border-yellow-500/30 bg-yellow-500/10 text-yellow-400",
+  split: "border-red-500/30 bg-red-500/10 text-red-400",
+  single_source: "border-lofi-border bg-lofi-surface text-lofi-muted",
+};
+
+const placementColor = (p: number) =>
+  p > 0 && p <= 4 ? "text-green-400" : "text-red-400";
+
+interface CompositionCardProps {
+  entry: TierListEntry;
+  championMap: Map<string, Champion>;
+  itemMap: Map<string, Item>;
+}
+
+export function CompositionCard({
+  entry,
+  championMap,
+  itemMap,
+}: CompositionCardProps) {
+  return (
+    <TerminalCard>
+      {/* Header */}
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Badge className="font-bold">{entry.consolidatedTier}</Badge>
+          <span className="text-xs font-medium text-white">
+            {entry.compositionName}
+          </span>
+        </div>
+        <ConfidenceIndicator level={entry.confidence} />
+      </div>
+
+      {/* Champion portraits */}
+      <div className="mb-3 flex flex-wrap gap-1.5">
+        {entry.coreChampions.map((apiName) => {
+          const champ = championMap.get(apiName);
+          return (
+            <div key={apiName} className="flex flex-col items-center gap-0.5">
+              {champ?.squareIconUrl ? (
+                <img
+                  src={champ.squareIconUrl}
+                  alt={champ.name}
+                  className="h-8 w-8 rounded-sm border border-lofi-border"
+                />
+              ) : (
+                <div className="flex h-8 w-8 items-center justify-center rounded-sm border border-lofi-border bg-lofi-black text-[8px] text-lofi-muted">
+                  {apiName.split("_").pop()?.slice(0, 3)}
+                </div>
+              )}
+              {/* Items for this champion */}
+              <div className="flex gap-0.5">
+                {(entry.recommendedItems[apiName]?.itemApiNames ?? []).map(
+                  (itemApi, idx) => {
+                    const item = itemMap.get(itemApi);
+                    return item?.iconUrl ? (
+                      <img
+                        key={idx}
+                        src={item.iconUrl}
+                        alt={item.name}
+                        className="h-3.5 w-3.5 rounded-sm"
+                      />
+                    ) : (
+                      <div
+                        key={idx}
+                        className="h-3.5 w-3.5 rounded-sm bg-lofi-border"
+                      />
+                    );
+                  },
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Stats row */}
+      <div className="mb-2 flex items-center gap-4 text-[10px]">
+        {entry.avgWinRate > 0 && (
+          <span className="text-lofi-secondary">
+            win{" "}
+            <span className="text-green-400">
+              {entry.avgWinRate.toFixed(1)}%
+            </span>
+          </span>
+        )}
+        {entry.avgPlayRate > 0 && (
+          <span className="text-lofi-secondary">
+            play{" "}
+            <span className="text-lofi-text">
+              {entry.avgPlayRate.toFixed(1)}%
+            </span>
+          </span>
+        )}
+        {entry.avgPlacement > 0 && (
+          <span className="text-lofi-secondary">
+            avg{" "}
+            <span className={placementColor(entry.avgPlacement)}>
+              {entry.avgPlacement.toFixed(2)}
+            </span>
+          </span>
+        )}
+      </div>
+
+      {/* Consensus badge */}
+      <div className="flex items-center gap-2">
+        <span
+          className={`inline-flex items-center rounded-sm border px-1.5 py-0.5 text-[10px] ${
+            consensusStyles[entry.consensus] ?? consensusStyles.split
+          }`}
+        >
+          {entry.consensus}
+        </span>
+      </div>
+
+      {/* Source breakdown */}
+      <SourceBreakdown
+        metatftTier={entry.metatftTier}
+        tftacticsTier={entry.tftacticsTier}
+        mobalyticsTier={entry.mobalyticsTier}
+      />
+    </TerminalCard>
+  );
+}

--- a/frontend/src/components/tier-list/confidence-indicator.tsx
+++ b/frontend/src/components/tier-list/confidence-indicator.tsx
@@ -1,0 +1,20 @@
+const styles: Record<string, string> = {
+  high: "bg-green-500",
+  medium: "bg-yellow-500",
+  low: "bg-red-500",
+};
+
+interface ConfidenceIndicatorProps {
+  level: string;
+}
+
+export function ConfidenceIndicator({ level }: ConfidenceIndicatorProps) {
+  const dotColor = styles[level] ?? styles.low;
+
+  return (
+    <span className="inline-flex items-center gap-1 text-[10px] text-lofi-secondary">
+      <span className={`h-1.5 w-1.5 rounded-full ${dotColor}`} />
+      {level}
+    </span>
+  );
+}

--- a/frontend/src/components/tier-list/crawl-status-footer.tsx
+++ b/frontend/src/components/tier-list/crawl-status-footer.tsx
@@ -1,0 +1,31 @@
+interface CrawlStatusFooterProps {
+  lastUpdated: string;
+}
+
+export function CrawlStatusFooter({ lastUpdated }: CrawlStatusFooterProps) {
+  const formatted = lastUpdated
+    ? formatRelativeTime(lastUpdated)
+    : "never";
+
+  return (
+    <div className="mt-6 border-t border-lofi-border pt-3 text-[10px] text-lofi-muted">
+      last updated: {formatted} // sources: metatft + tftactics + mobalytics
+    </div>
+  );
+}
+
+function formatRelativeTime(iso: string): string {
+  const date = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+
+  const diffD = Math.floor(diffH / 24);
+  return `${diffD}d ago`;
+}

--- a/frontend/src/components/tier-list/source-breakdown.tsx
+++ b/frontend/src/components/tier-list/source-breakdown.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+
+interface SourceBreakdownProps {
+  metatftTier: string;
+  tftacticsTier: string;
+  mobalyticsTier: string;
+}
+
+const sources = [
+  { key: "metatftTier" as const, label: "MetaTFT" },
+  { key: "tftacticsTier" as const, label: "TFTactics" },
+  { key: "mobalyticsTier" as const, label: "Mobalytics" },
+];
+
+export function SourceBreakdown({
+  metatftTier,
+  tftacticsTier,
+  mobalyticsTier,
+}: SourceBreakdownProps) {
+  const [open, setOpen] = useState(false);
+
+  const tiers: Record<string, string> = {
+    metatftTier,
+    tftacticsTier,
+    mobalyticsTier,
+  };
+
+  return (
+    <div className="mt-2 border-t border-lofi-border pt-2">
+      <button
+        onClick={() => setOpen(!open)}
+        className="text-[10px] text-lofi-muted hover:text-lofi-secondary transition-colors"
+      >
+        {open ? "- hide sources" : "+ view sources"}
+      </button>
+
+      {open && (
+        <div className="mt-2 space-y-1">
+          {sources.map((s) => (
+            <div
+              key={s.key}
+              className="flex items-center justify-between text-[10px]"
+            >
+              <span className="text-lofi-muted">{s.label}</span>
+              <span className="text-lofi-secondary">
+                {tiers[s.key] || "—"}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/tier-list/tier-list-skeleton.tsx
+++ b/frontend/src/components/tier-list/tier-list-skeleton.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function TierListSkeleton() {
+  return (
+    <div className="space-y-6">
+      {["S", "A", "B", "C"].map((tier) => (
+        <div key={tier} className="border-l-4 border-l-lofi-border pl-3">
+          <Skeleton className="mb-3 h-6 w-16" />
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+            {Array.from({ length: tier === "S" ? 2 : 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-36" />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/tier-list/tier-section.tsx
+++ b/frontend/src/components/tier-list/tier-section.tsx
@@ -1,0 +1,61 @@
+import type { TierListEntry } from "@/gen/tft/v1/tierlist_pb";
+import type { Champion, Item } from "@/gen/tft/v1/patch_pb";
+import { CompositionCard } from "./composition-card";
+
+const tierStyles: Record<string, string> = {
+  S: "border-l-4 border-l-yellow-500",
+  A: "border-l-4 border-l-green-500",
+  B: "border-l-4 border-l-blue-500",
+  C: "border-l-4 border-l-lofi-muted",
+  D: "border-l-4 border-l-lofi-border",
+};
+
+const tierLabelStyles: Record<string, string> = {
+  S: "text-yellow-500",
+  A: "text-green-500",
+  B: "text-blue-500",
+  C: "text-lofi-muted",
+  D: "text-lofi-border",
+};
+
+interface TierSectionProps {
+  tier: string;
+  entries: TierListEntry[];
+  championMap: Map<string, Champion>;
+  itemMap: Map<string, Item>;
+}
+
+export function TierSection({
+  tier,
+  entries,
+  championMap,
+  itemMap,
+}: TierSectionProps) {
+  if (entries.length === 0) return null;
+
+  return (
+    <div className={`mb-6 rounded-sm pl-3 ${tierStyles[tier] ?? ""}`}>
+      <div className="mb-3 flex items-center gap-2">
+        <span
+          className={`text-lg font-black ${tierLabelStyles[tier] ?? "text-lofi-muted"}`}
+        >
+          {tier}
+        </span>
+        <span className="text-[10px] text-lofi-muted">
+          {entries.length} comp{entries.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        {entries.map((entry) => (
+          <CompositionCard
+            key={entry.compositionName}
+            entry={entry}
+            championMap={championMap}
+            itemMap={itemMap}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -11,7 +11,7 @@ export function Button({
   ...props
 }: ButtonProps) {
   const base =
-    "inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-lofi-accent disabled:pointer-events-none disabled:opacity-50";
+    "inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-lofi-accent disabled:pointer-events-none disabled:opacity-50 active:scale-95";
 
   const variants = {
     primary: "bg-lofi-text text-lofi-black hover:opacity-80",

--- a/frontend/src/components/ui/generic-empty-state.tsx
+++ b/frontend/src/components/ui/generic-empty-state.tsx
@@ -1,0 +1,37 @@
+import { Button } from "@/components/ui/button";
+
+interface GenericEmptyStateProps {
+  title: string;
+  description: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+export function GenericEmptyState({
+  title,
+  description,
+  actionLabel,
+  onAction,
+}: GenericEmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16">
+      <div className="mb-6 flex h-12 w-12 items-center justify-center rounded-lg border border-lofi-border bg-lofi-surface">
+        <span className="text-xl font-bold text-lofi-muted">//</span>
+      </div>
+
+      <h3 className="mb-1 text-xs font-bold uppercase tracking-widest text-lofi-secondary">
+        {title}
+      </h3>
+
+      <p className="mb-6 max-w-xs text-center text-[10px] leading-relaxed text-lofi-muted">
+        {description}
+      </p>
+
+      {actionLabel && onAction && (
+        <Button variant="secondary" onClick={onAction}>
+          {actionLabel}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/inline-error.tsx
+++ b/frontend/src/components/ui/inline-error.tsx
@@ -1,0 +1,22 @@
+import { Button } from "@/components/ui/button";
+
+interface InlineErrorProps {
+  message: string;
+  onRetry?: () => void;
+}
+
+export function InlineError({ message, onRetry }: InlineErrorProps) {
+  return (
+    <div className="flex items-center justify-between rounded-sm border border-red-500/30 bg-red-500/10 px-4 py-3">
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-red-400">!</span>
+        <span className="text-xs text-red-400">{message}</span>
+      </div>
+      {onRetry && (
+        <Button variant="secondary" onClick={onRetry} className="ml-4 text-red-400 border-red-500/30 hover:bg-red-500/10">
+          retry
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/page-transition.tsx
+++ b/frontend/src/components/ui/page-transition.tsx
@@ -13,7 +13,7 @@ export function PageTransition({ children }: { children: React.ReactNode }) {
 
   return (
     <div
-      className={`transition-all duration-200 ease-out ${
+      className={`will-change-transform transition-all duration-200 ease-out ${
         visible ? "translate-y-0 opacity-100" : "translate-y-1 opacity-0"
       }`}
     >

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -1,15 +1,23 @@
 import { useState, useEffect, useCallback, createContext, useContext } from "react";
 
-type ToastType = "success" | "error" | "info";
+type ToastType = "success" | "error" | "info" | "warning";
 
 interface Toast {
   id: number;
   message: string;
   type: ToastType;
+  duration: number;
+  action?: { label: string; onClick: () => void };
+}
+
+interface ToastOptions {
+  type?: ToastType;
+  duration?: number;
+  action?: { label: string; onClick: () => void };
 }
 
 interface ToastContextValue {
-  toast: (message: string, type?: ToastType) => void;
+  toast: (message: string, options?: ToastType | ToastOptions) => void;
 }
 
 const ToastContext = createContext<ToastContextValue>({
@@ -20,15 +28,30 @@ export function useToast() {
   return useContext(ToastContext);
 }
 
+const DEFAULT_DURATION = 3000;
 let nextId = 0;
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
-  const addToast = useCallback((message: string, type: ToastType = "info") => {
-    const id = nextId++;
-    setToasts((prev) => [...prev, { id, message, type }]);
-  }, []);
+  const addToast = useCallback(
+    (message: string, options?: ToastType | ToastOptions) => {
+      const id = nextId++;
+      const opts: ToastOptions =
+        typeof options === "string" ? { type: options } : options ?? {};
+      setToasts((prev) => [
+        ...prev,
+        {
+          id,
+          message,
+          type: opts.type ?? "info",
+          duration: opts.duration ?? DEFAULT_DURATION,
+          action: opts.action,
+        },
+      ]);
+    },
+    [],
+  );
 
   const removeToast = useCallback((id: number) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
@@ -50,6 +73,7 @@ const typeStyles: Record<ToastType, string> = {
   success: "border-green-500/30 bg-green-500/10 text-green-400",
   error: "border-red-500/30 bg-red-500/10 text-red-400",
   info: "border-lofi-accent/30 bg-lofi-accent/10 text-lofi-accent",
+  warning: "border-yellow-500/30 bg-yellow-500/10 text-yellow-400",
 };
 
 function ToastItem({
@@ -68,20 +92,31 @@ function ToastItem({
     const timer = setTimeout(() => {
       setVisible(false);
       setTimeout(() => onDismiss(toast.id), 200);
-    }, 3000);
+    }, toast.duration);
 
     return () => clearTimeout(timer);
-  }, [toast.id, onDismiss]);
+  }, [toast.id, toast.duration, onDismiss]);
 
   return (
     <div
-      className={`rounded-sm border px-4 py-2 text-xs font-medium shadow-lg backdrop-blur-sm transition-all duration-200 ${typeStyles[toast.type]} ${
+      className={`flex items-center gap-3 rounded-sm border px-4 py-2 text-xs font-medium shadow-lg backdrop-blur-sm transition-all duration-200 ${typeStyles[toast.type]} ${
         visible
           ? "translate-x-0 opacity-100"
           : "translate-x-4 opacity-0"
       }`}
     >
-      {toast.message}
+      <span>{toast.message}</span>
+      {toast.action && (
+        <button
+          onClick={() => {
+            toast.action!.onClick();
+            onDismiss(toast.id);
+          }}
+          className="ml-auto shrink-0 underline underline-offset-2 hover:opacity-80"
+        >
+          {toast.action.label}
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/use-tier-list.ts
+++ b/frontend/src/hooks/use-tier-list.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { tierListClient } from "@/lib/transport";
+
+export function useTierList(patch = "", tierFilter = "") {
+  return useQuery({
+    queryKey: ["tierList", patch, tierFilter],
+    queryFn: () =>
+      tierListClient.getConsolidatedTierList({ patch, tierFilter }),
+    staleTime: 10 * 60 * 1000, // 10 minutes
+    retry: 1,
+  });
+}

--- a/frontend/src/lib/transport.ts
+++ b/frontend/src/lib/transport.ts
@@ -4,6 +4,7 @@ import { PatchService } from "@/gen/tft/v1/patch_pb";
 import { PlayerService } from "@/gen/tft/v1/player_pb";
 import { AuthService } from "@/gen/tft/v1/auth_pb";
 import { SimulationService } from "@/gen/tft/v1/simulation_pb";
+import { TierListService } from "@/gen/tft/v1/tierlist_pb";
 
 export const transport = createConnectTransport({
   baseUrl: "http://localhost:8080",
@@ -29,3 +30,4 @@ export const patchClient = createClient(PatchService, transport);
 export const playerClient = createClient(PlayerService, transport);
 export const authClient = createClient(AuthService, transport);
 export const simulationClient = createClient(SimulationService, transport);
+export const tierListClient = createClient(TierListService, transport);

--- a/frontend/src/pages/augments.tsx
+++ b/frontend/src/pages/augments.tsx
@@ -4,6 +4,8 @@ import { SectionHeader } from "@/components/layout/section-header";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { AugmentCard } from "@/components/augment-card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { InlineError } from "@/components/ui/inline-error";
+import { friendlyError } from "@/lib/error";
 
 const tierFilters = [
   { label: "silver", value: "silver" },
@@ -22,7 +24,7 @@ function getAugmentTier(tags: string[]): string | null {
 }
 
 export function AugmentsPage() {
-  const { data, isLoading, error } = usePatchData();
+  const { data, isLoading, error, refetch } = usePatchData();
   const [search, setSearch] = useState("");
   const [tierFilter, setTierFilter] = useState("all");
 
@@ -44,8 +46,9 @@ export function AugmentsPage() {
 
   if (error) {
     return (
-      <div className="text-xs text-red-400">
-        error: {error.message}
+      <div>
+        <SectionHeader number="05" title="augments" />
+        <InlineError message={friendlyError(error)} onRetry={() => refetch()} />
       </div>
     );
   }

--- a/frontend/src/pages/champions.tsx
+++ b/frontend/src/pages/champions.tsx
@@ -4,6 +4,8 @@ import { SectionHeader } from "@/components/layout/section-header";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ChampionCard } from "@/components/champion-card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { InlineError } from "@/components/ui/inline-error";
+import { friendlyError } from "@/lib/error";
 
 const costFilters = [
   { label: "1g", value: "1" },
@@ -14,7 +16,7 @@ const costFilters = [
 ];
 
 export function ChampionsPage() {
-  const { data, isLoading, error } = usePatchData();
+  const { data, isLoading, error, refetch } = usePatchData();
   const [search, setSearch] = useState("");
   const [costFilter, setCostFilter] = useState("all");
 
@@ -41,8 +43,9 @@ export function ChampionsPage() {
 
   if (error) {
     return (
-      <div className="text-xs text-red-400">
-        error: {error.message}
+      <div>
+        <SectionHeader number="01" title="champions" />
+        <InlineError message={friendlyError(error)} onRetry={() => refetch()} />
       </div>
     );
   }

--- a/frontend/src/pages/items.tsx
+++ b/frontend/src/pages/items.tsx
@@ -4,6 +4,8 @@ import { SectionHeader } from "@/components/layout/section-header";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ItemCard } from "@/components/item-card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { InlineError } from "@/components/ui/inline-error";
+import { friendlyError } from "@/lib/error";
 
 const typeFilters = [
   { label: "component", value: "component" },
@@ -11,7 +13,7 @@ const typeFilters = [
 ];
 
 export function ItemsPage() {
-  const { data, isLoading, error } = usePatchData();
+  const { data, isLoading, error, refetch } = usePatchData();
   const [search, setSearch] = useState("");
   const [typeFilter, setTypeFilter] = useState("all");
 
@@ -35,8 +37,9 @@ export function ItemsPage() {
 
   if (error) {
     return (
-      <div className="text-xs text-red-400">
-        error: {error.message}
+      <div>
+        <SectionHeader number="02" title="items" />
+        <InlineError message={friendlyError(error)} onRetry={() => refetch()} />
       </div>
     );
   }

--- a/frontend/src/pages/tier-list.tsx
+++ b/frontend/src/pages/tier-list.tsx
@@ -1,0 +1,138 @@
+import { useState, useMemo } from "react";
+import { useTierList } from "@/hooks/use-tier-list";
+import { usePatchData } from "@/hooks/use-patch-data";
+import { SectionHeader } from "@/components/layout/section-header";
+import { SearchFilterBar } from "@/components/search-filter-bar";
+import { TierSection } from "@/components/tier-list/tier-section";
+import { TierListSkeleton } from "@/components/tier-list/tier-list-skeleton";
+import { CrawlStatusFooter } from "@/components/tier-list/crawl-status-footer";
+import { InlineError } from "@/components/ui/inline-error";
+import { GenericEmptyState } from "@/components/ui/generic-empty-state";
+import { friendlyError } from "@/lib/error";
+import type { TierListEntry } from "@/gen/tft/v1/tierlist_pb";
+import type { Champion, Item } from "@/gen/tft/v1/patch_pb";
+
+const tierFilters = [
+  { label: "S", value: "S" },
+  { label: "A", value: "A" },
+  { label: "B", value: "B" },
+  { label: "C", value: "C" },
+];
+
+const TIER_ORDER = ["S", "A", "B", "C", "D"];
+
+export function TierListPage() {
+  const { data, isLoading, error, refetch } = useTierList();
+  const { data: patchData } = usePatchData();
+  const [search, setSearch] = useState("");
+  const [tierFilter, setTierFilter] = useState("all");
+
+  // Build lookup maps from patch data
+  const championMap = useMemo(() => {
+    const map = new Map<string, Champion>();
+    for (const c of patchData?.champions ?? []) {
+      map.set(c.apiName, c);
+    }
+    return map;
+  }, [patchData?.champions]);
+
+  const itemMap = useMemo(() => {
+    const map = new Map<string, Item>();
+    for (const i of patchData?.items ?? []) {
+      map.set(i.apiName, i);
+    }
+    return map;
+  }, [patchData?.items]);
+
+  // Filter entries
+  const filtered = useMemo(() => {
+    const entries = data?.entries ?? [];
+    return entries.filter((e) => {
+      const matchesTier =
+        tierFilter === "all" || e.consolidatedTier === tierFilter;
+      const matchesSearch =
+        !search ||
+        e.compositionName.toLowerCase().includes(search.toLowerCase()) ||
+        e.coreChampions.some((id) => {
+          const champ = championMap.get(id);
+          return champ?.name.toLowerCase().includes(search.toLowerCase());
+        });
+      return matchesTier && matchesSearch;
+    });
+  }, [data?.entries, tierFilter, search, championMap]);
+
+  // Group by tier
+  const groupedByTier = useMemo(() => {
+    const groups = new Map<string, TierListEntry[]>();
+    for (const tier of TIER_ORDER) {
+      groups.set(tier, []);
+    }
+    for (const entry of filtered) {
+      const list = groups.get(entry.consolidatedTier);
+      if (list) {
+        list.push(entry);
+      }
+    }
+    return groups;
+  }, [filtered]);
+
+  if (error) {
+    return (
+      <div>
+        <SectionHeader number="08" title="tier list" />
+        <InlineError message={friendlyError(error)} onRetry={() => refetch()} />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <SectionHeader number="08" title="tier list" />
+
+      <SearchFilterBar
+        searchValue={search}
+        onSearchChange={setSearch}
+        searchPlaceholder="search compositions or champions..."
+        filters={tierFilters}
+        activeFilter={tierFilter}
+        onFilterChange={setTierFilter}
+      />
+
+      {isLoading ? (
+        <TierListSkeleton />
+      ) : filtered.length === 0 ? (
+        <GenericEmptyState
+          title="NO_DATA"
+          description="no compositions found. the crawler may not have run yet, or no results match your filters."
+          actionLabel="clear filters"
+          onAction={() => {
+            setSearch("");
+            setTierFilter("all");
+          }}
+        />
+      ) : (
+        <>
+          <p className="mb-4 text-[10px] text-lofi-muted">
+            {filtered.length} composition{filtered.length !== 1 ? "s" : ""}
+            {data?.patch ? ` // patch ${data.patch}` : ""}
+          </p>
+
+          {TIER_ORDER.map((tier) => {
+            const entries = groupedByTier.get(tier) ?? [];
+            return (
+              <TierSection
+                key={tier}
+                tier={tier}
+                entries={entries}
+                championMap={championMap}
+                itemMap={itemMap}
+              />
+            );
+          })}
+
+          <CrawlStatusFooter lastUpdated={data?.lastUpdated ?? ""} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -20,6 +20,11 @@
   /* Font family */
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono",
     Menlo, Consolas, monospace;
+
+  /* Animation timing */
+  --duration-fast: 100ms;
+  --duration-normal: 200ms;
+  --duration-slow: 300ms;
 }
 
 /* Light theme — override lofi palette CSS variables */

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,6 +16,19 @@ export default defineConfig({
   },
   build: {
     outDir: "dist",
-    sourcemap: true,
+    sourcemap: false,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ["react", "react-dom", "react-router-dom"],
+          query: ["@tanstack/react-query"],
+          connect: [
+            "@connectrpc/connect",
+            "@connectrpc/connect-web",
+            "@bufbuild/protobuf",
+          ],
+        },
+      },
+    },
   },
 });

--- a/migrations/000011_create_raw_tier_data.down.sql
+++ b/migrations/000011_create_raw_tier_data.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS raw_tier_data;

--- a/migrations/000011_create_raw_tier_data.up.sql
+++ b/migrations/000011_create_raw_tier_data.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE raw_tier_data (
+    id               SERIAL PRIMARY KEY,
+    source           VARCHAR(50) NOT NULL,
+    patch            VARCHAR(20) NOT NULL,
+    composition_name VARCHAR(255) NOT NULL,
+    tier             VARCHAR(5),
+    win_rate         DECIMAL(5,2),
+    play_rate        DECIMAL(5,2),
+    avg_placement    DECIMAL(3,2),
+    champion_ids     TEXT[] NOT NULL DEFAULT '{}',
+    core_items       JSONB NOT NULL DEFAULT '{}',
+    scraped_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_raw_tier_source ON raw_tier_data(source);
+CREATE INDEX idx_raw_tier_patch ON raw_tier_data(patch);
+CREATE INDEX idx_raw_tier_source_patch ON raw_tier_data(source, patch);

--- a/migrations/000012_create_consolidated_tier_list.down.sql
+++ b/migrations/000012_create_consolidated_tier_list.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS consolidated_tier_list;

--- a/migrations/000012_create_consolidated_tier_list.up.sql
+++ b/migrations/000012_create_consolidated_tier_list.up.sql
@@ -1,0 +1,22 @@
+CREATE TABLE consolidated_tier_list (
+    id                  SERIAL PRIMARY KEY,
+    patch               VARCHAR(20) NOT NULL,
+    composition_name    VARCHAR(255) NOT NULL,
+    consolidated_tier   VARCHAR(5) NOT NULL,
+    consolidated_score  DECIMAL(5,2) NOT NULL,
+    confidence          VARCHAR(20) NOT NULL DEFAULT 'low',
+    consensus           VARCHAR(30) NOT NULL DEFAULT 'unknown',
+    metatft_tier        VARCHAR(5),
+    tftactics_tier      VARCHAR(5),
+    mobalytics_tier     VARCHAR(5),
+    avg_win_rate        DECIMAL(5,2),
+    avg_play_rate       DECIMAL(5,2),
+    avg_placement       DECIMAL(3,2),
+    core_champions      TEXT[] NOT NULL DEFAULT '{}',
+    recommended_items   JSONB NOT NULL DEFAULT '{}',
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (patch, composition_name)
+);
+
+CREATE INDEX idx_consolidated_patch ON consolidated_tier_list(patch);
+CREATE INDEX idx_consolidated_tier ON consolidated_tier_list(consolidated_tier);

--- a/proto/tft/v1/tierlist.proto
+++ b/proto/tft/v1/tierlist.proto
@@ -1,0 +1,80 @@
+syntax = "proto3";
+
+package tft.v1;
+
+option go_package = "github.com/MeninoNias/tft-oracle/backend/gen/tft/v1;tftv1";
+
+// TierListService provides cross-source consolidated tier list data.
+service TierListService {
+  // GetConsolidatedTierList returns the merged tier list for a patch.
+  rpc GetConsolidatedTierList(GetConsolidatedTierListRequest) returns (GetConsolidatedTierListResponse);
+  // TriggerCrawl manually triggers a crawl cycle.
+  rpc TriggerCrawl(TriggerCrawlRequest) returns (TriggerCrawlResponse);
+  // GetCrawlerStatus returns the last crawl timestamps and per-source status.
+  rpc GetCrawlerStatus(GetCrawlerStatusRequest) returns (GetCrawlerStatusResponse);
+}
+
+message GetConsolidatedTierListRequest {
+  // Patch version (e.g. "14.10"). Empty = latest available.
+  string patch = 1;
+  // Filter by tier (e.g. "S"). Empty = all tiers.
+  string tier_filter = 2;
+}
+
+message GetConsolidatedTierListResponse {
+  string patch = 1;
+  repeated TierListEntry entries = 2;
+  // ISO 8601 timestamp of last consolidation.
+  string last_updated = 3;
+}
+
+message TierListEntry {
+  string composition_name = 1;
+  // Consolidated tier: "S", "A", "B", "C", "D".
+  string consolidated_tier = 2;
+  // Numeric score (0-100).
+  double consolidated_score = 3;
+  // "high", "medium", "low".
+  string confidence = 4;
+  // "unanimous", "majority", "split", "single_source".
+  string consensus = 5;
+  // Per-source tiers (empty string if source didn't have this comp).
+  string metatft_tier = 6;
+  string tftactics_tier = 7;
+  string mobalytics_tier = 8;
+  // Consolidated stats.
+  double avg_win_rate = 9;
+  double avg_play_rate = 10;
+  double avg_placement = 11;
+  // Champion api_names in this composition.
+  repeated string core_champions = 12;
+  // Recommended items per champion: champion_api_name -> item list.
+  map<string, ItemList> recommended_items = 13;
+}
+
+message ItemList {
+  repeated string item_api_names = 1;
+}
+
+message TriggerCrawlRequest {}
+
+message TriggerCrawlResponse {
+  string message = 1;
+}
+
+message GetCrawlerStatusRequest {}
+
+message GetCrawlerStatusResponse {
+  repeated SourceStatus sources = 1;
+  // ISO 8601 timestamp of last consolidation run.
+  string last_consolidation = 2;
+}
+
+message SourceStatus {
+  string source = 1;
+  // ISO 8601 timestamp of last successful scrape.
+  string last_scraped = 2;
+  // "ok", "error", "never".
+  string status = 3;
+  string error_message = 4;
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,9 +1,16 @@
 [package]
 name = "tft-oracle"
-version = "0.1.0"
+version = "0.4.0"
 description = "TFT Oracle — AI-powered TFT coach"
 authors = ["MeninoNias"]
 edition = "2021"
+
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1
+opt-level = "s"
+panic = "abort"
 
 [lib]
 name = "tft_oracle_lib"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "TFT Oracle",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "identifier": "com.tft-oracle.app",
   "build": {
     "frontendDist": "../frontend/dist",
@@ -15,6 +15,8 @@
         "title": "TFT Oracle",
         "width": 1200,
         "height": 800,
+        "minWidth": 800,
+        "minHeight": 600,
         "resizable": true,
         "fullscreen": false
       }
@@ -22,5 +24,15 @@
     "security": {
       "csp": "default-src 'self'; connect-src 'self' http://localhost:8080; img-src 'self' https://raw.communitydragon.org data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com"
     }
+  },
+  "bundle": {
+    "active": true,
+    "targets": ["msi", "nsis"],
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.ico"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Implements all 5 issues in Phase 4: Crawler & Launch — the final pre-launch phase that delivers the **Super Tier List** (cross-referencing multiple meta sites into a single authoritative tier list with confidence scoring), UX polish across the app, and the Tauri build pipeline for Windows distribution.

- **Go Crawler (#22)**: Concurrent scraper system with Mobalytics (GraphQL API), tactics.tools (`__NEXT_DATA__` parsing), and MetaTFT (stub for future headless browser). In-process scheduler, retry logic, rate limiting, safe transactional storage.
- **Consolidation Engine (#23)**: Jaccard similarity matching (80% threshold), weighted cross-ranking scorer, confidence/consensus detection. New `TierListService` with `GetConsolidatedTierList`, `TriggerCrawl`, `GetCrawlerStatus` RPCs.
- **Super Tier List UI (#24)**: New `/tier-list` page with S/A/B/C tier sections, composition cards (champion portraits, items, stats, confidence, consensus), expandable source breakdown, search + filters, loading skeletons.
- **UX Polish (#17)**: `InlineError` with retry (retrofitted across 3 pages), `GenericEmptyState`, enhanced toast system (warning type, duration, actions), micro-interactions, animation timing CSS variables.
- **Tauri Build Pipeline (#18)**: Release profile optimization (strip, LTO, opt-level=s), vendor chunk splitting, GitHub Actions release workflow (tag → Windows .exe/.msi → GitHub Releases).

## Test plan

- [ ] Start backend (`cd backend && go run ./cmd/server`) — verify crawler runs on startup, logs `stored X compositions from mobalytics` and `stored Y compositions from tacticstools`
- [ ] Open `http://localhost:5173/tier-list` — verify compositions render grouped by S/A/B/C tiers with champion portraits and stats
- [ ] Test tier filter buttons (S/A/B/C) and search bar
- [ ] Click "+ view sources" on a composition card — verify source breakdown expands
- [ ] Kill backend → verify InlineError with retry button appears on champions/items/augments pages
- [ ] Trigger manual crawl: `curl -X POST http://localhost:8080/tft.v1.TierListService/TriggerCrawl -H "Content-Type: application/json" -d '{}'`
- [ ] Verify `buf lint` and `buf generate` pass
- [ ] Verify `cd backend && go test ./...` passes
- [ ] Verify `cd frontend && npx tsc --noEmit` passes

Closes #22, Closes #23, Closes #24, Closes #17, Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)