### PR TITLE
feat: AI Coach — post-game match analysis with personalized coaching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-tauri:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Buf CLI
+        uses: bufbuild/buf-setup-action@v1
+
+      - name: Generate protobuf code
+        run: buf generate
+
+      - name: Build Tauri
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: "TFT Oracle ${{ github.ref_name }}"
+          releaseBody: "See the assets to download this version."
+          releaseDraft: true
+          prerelease: false

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -161,3 +161,12 @@ tasks:
     dir: "{{.TAURI_DIR}}"
     cmds:
       - cargo tauri build
+
+  # ========================
+  # Release
+  # ========================
+  release:
+    desc: Create a release tag and push (triggers GitHub Actions)
+    cmds:
+      - git tag -a v{{.CLI_ARGS}} -m "Release v{{.CLI_ARGS}}"
+      - git push origin v{{.CLI_ARGS}}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -23,11 +23,14 @@ import (
 	"github.com/MeninoNias/tft-oracle/backend/internal/cache"
 	"github.com/MeninoNias/tft-oracle/backend/internal/cdragon"
 	"github.com/MeninoNias/tft-oracle/backend/internal/config"
+	"github.com/MeninoNias/tft-oracle/backend/internal/consolidation"
+	"github.com/MeninoNias/tft-oracle/backend/internal/crawler"
 	"github.com/MeninoNias/tft-oracle/backend/internal/database"
 	"github.com/MeninoNias/tft-oracle/backend/internal/patch"
 	"github.com/MeninoNias/tft-oracle/backend/internal/player"
 	"github.com/MeninoNias/tft-oracle/backend/internal/riot"
 	"github.com/MeninoNias/tft-oracle/backend/internal/simulation"
+	"github.com/MeninoNias/tft-oracle/backend/internal/tierlist"
 )
 
 func main() {
@@ -122,6 +125,28 @@ func main() {
 		log.Println("openai: OPENAI_API_KEY not set — simulation features disabled")
 	}
 
+	// Crawler & consolidation (Phase 4)
+	consolidationEngine := consolidation.NewEngine(pool, nil)
+	httpClient := crawler.NewHTTPClient()
+	scrapers := []crawler.Scraper{
+		crawler.NewMobalyticsScraper(httpClient),
+		crawler.NewTacticsToolsScraper(httpClient),
+		crawler.NewMetaTFTScraper(httpClient),
+	}
+
+	crawlerInterval := 24 * time.Hour
+	if d, err := time.ParseDuration(cfg.CrawlerInterval); err == nil {
+		crawlerInterval = d
+	}
+
+	crawl := crawler.New(pool, scrapers, crawlerInterval, consolidationEngine.Consolidate)
+	if cfg.CrawlerEnabled {
+		go crawl.StartScheduler(ctx)
+		log.Println("crawler: enabled")
+	} else {
+		log.Println("crawler: disabled")
+	}
+
 	// Set up Connect RPC handlers
 	mux := http.NewServeMux()
 
@@ -153,6 +178,12 @@ func main() {
 		interceptors,
 	)
 	mux.Handle(simPath, simHandler)
+
+	tierListPath, tierListHandler := tftv1connect.NewTierListServiceHandler(
+		tierlist.NewService(pool, crawl),
+		interceptors,
+	)
+	mux.Handle(tierListPath, tierListHandler)
 
 	// CORS configuration
 	corsHandler := cors.New(cors.Options{

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/MeninoNias/tft-oracle/backend/gen/tft/v1/tftv1connect"
 	"github.com/MeninoNias/tft-oracle/backend/internal/ai"
 	"github.com/MeninoNias/tft-oracle/backend/internal/auth"
+	"github.com/MeninoNias/tft-oracle/backend/internal/coach"
 	"github.com/MeninoNias/tft-oracle/backend/internal/cache"
 	"github.com/MeninoNias/tft-oracle/backend/internal/cdragon"
 	"github.com/MeninoNias/tft-oracle/backend/internal/config"
@@ -184,6 +185,12 @@ func main() {
 		interceptors,
 	)
 	mux.Handle(tierListPath, tierListHandler)
+
+	coachPath, coachHandler := tftv1connect.NewCoachServiceHandler(
+		coach.NewService(pool, aiClient),
+		interceptors,
+	)
+	mux.Handle(coachPath, coachHandler)
 
 	// CORS configuration
 	corsHandler := cors.New(cors.Options{

--- a/backend/internal/ai/client.go
+++ b/backend/internal/ai/client.go
@@ -14,8 +14,12 @@ import (
 )
 
 const (
-	defaultModel   = "gpt-4o-mini"
-	defaultTimeout = 30 * time.Second
+	defaultModel        = "gpt-4o-mini"
+	defaultTimeout      = 30 * time.Second
+	coachTimeout        = 60 * time.Second
+	coachMatchMaxTokens = 2000
+	coachHistMaxTokens  = 3000
+	coachTemperature    = 0.4
 )
 
 // Client wraps the OpenAI API for TFT battle analysis.
@@ -91,4 +95,106 @@ func (c *Client) AnalyzeBattle(ctx context.Context, prompt string) (*BattleAnaly
 	}
 
 	return &analysis, nil
+}
+
+// AnalyzeMatchCoaching sends match data to GPT and returns structured coaching analysis.
+// Returns the analysis and total tokens used for cost tracking.
+func (c *Client) AnalyzeMatchCoaching(ctx context.Context, prompt string) (*MatchCoachAnalysis, int64, error) {
+	if !c.Available() {
+		return nil, 0, fmt.Errorf("OPENAI_API_KEY not configured")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, coachTimeout)
+	defer cancel()
+
+	completion, err := c.client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+		Model: openai.ChatModel(c.model),
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage(CoachMatchSystemPrompt),
+			openai.UserMessage(prompt),
+		},
+		Temperature:         param.Opt[float64]{Value: coachTemperature},
+		MaxCompletionTokens: param.Opt[int64]{Value: coachMatchMaxTokens},
+		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
+			OfJSONSchema: &shared.ResponseFormatJSONSchemaParam{
+				JSONSchema: shared.ResponseFormatJSONSchemaJSONSchemaParam{
+					Name:   "match_coach_analysis",
+					Strict: param.Opt[bool]{Value: true},
+					Schema: MatchCoachAnalysisSchema,
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, 0, fmt.Errorf("openai coach match analysis: %w", err)
+	}
+
+	if len(completion.Choices) == 0 {
+		return nil, 0, fmt.Errorf("openai returned no choices")
+	}
+
+	tokensUsed := completion.Usage.TotalTokens
+	if tokensUsed > 0 {
+		log.Printf("openai coach-match: %d tokens used (prompt=%d, completion=%d)",
+			tokensUsed, completion.Usage.PromptTokens, completion.Usage.CompletionTokens)
+	}
+
+	content := completion.Choices[0].Message.Content
+	var analysis MatchCoachAnalysis
+	if err := json.Unmarshal([]byte(content), &analysis); err != nil {
+		return nil, tokensUsed, fmt.Errorf("parse coach match response: %w", err)
+	}
+
+	return &analysis, tokensUsed, nil
+}
+
+// AnalyzeHistoryCoaching sends multi-match data to GPT and returns structured coaching analysis.
+// Returns the analysis and total tokens used for cost tracking.
+func (c *Client) AnalyzeHistoryCoaching(ctx context.Context, prompt string) (*HistoryCoachAnalysis, int64, error) {
+	if !c.Available() {
+		return nil, 0, fmt.Errorf("OPENAI_API_KEY not configured")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, coachTimeout)
+	defer cancel()
+
+	completion, err := c.client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+		Model: openai.ChatModel(c.model),
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage(CoachHistorySystemPrompt),
+			openai.UserMessage(prompt),
+		},
+		Temperature:         param.Opt[float64]{Value: coachTemperature},
+		MaxCompletionTokens: param.Opt[int64]{Value: coachHistMaxTokens},
+		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
+			OfJSONSchema: &shared.ResponseFormatJSONSchemaParam{
+				JSONSchema: shared.ResponseFormatJSONSchemaJSONSchemaParam{
+					Name:   "history_coach_analysis",
+					Strict: param.Opt[bool]{Value: true},
+					Schema: HistoryCoachAnalysisSchema,
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, 0, fmt.Errorf("openai coach history analysis: %w", err)
+	}
+
+	if len(completion.Choices) == 0 {
+		return nil, 0, fmt.Errorf("openai returned no choices")
+	}
+
+	tokensUsed := completion.Usage.TotalTokens
+	if tokensUsed > 0 {
+		log.Printf("openai coach-history: %d tokens used (prompt=%d, completion=%d)",
+			tokensUsed, completion.Usage.PromptTokens, completion.Usage.CompletionTokens)
+	}
+
+	content := completion.Choices[0].Message.Content
+	var analysis HistoryCoachAnalysis
+	if err := json.Unmarshal([]byte(content), &analysis); err != nil {
+		return nil, tokensUsed, fmt.Errorf("parse coach history response: %w", err)
+	}
+
+	return &analysis, tokensUsed, nil
 }

--- a/backend/internal/ai/coach_prompt.go
+++ b/backend/internal/ai/coach_prompt.go
@@ -1,0 +1,607 @@
+package ai
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// --- Helper types for prompt building ---
+
+// MatchMeta holds match-level metadata for prompt context.
+type MatchMeta struct {
+	GameLength float32
+	LastRound  int32
+	GameType   string
+}
+
+// TierListEntry holds a meta composition for prompt context.
+type TierListEntry struct {
+	CompositionName  string
+	Tier             string
+	Score            float64
+	CoreChampions    []string
+	RecommendedItems map[string][]string // champion apiName → item display names
+	WinRate          float64
+	AvgPlacement     float64
+}
+
+// MatchParticipantData holds participant data for prompt building.
+type MatchParticipantData struct {
+	Puuid                 string
+	Placement             int32
+	Level                 int32
+	GoldLeft              int32
+	LastRound             int32
+	TimeEliminated        float32
+	TotalDamageToPlayers  int32
+	PlayersEliminated     int32
+	Augments              []string
+	Traits                []ParticipantTrait
+	Units                 []ParticipantUnit
+}
+
+// ParticipantTrait is a trait from a match participant's JSONB data.
+type ParticipantTrait struct {
+	ApiName     string
+	NumUnits    int32
+	Style       int32
+	TierCurrent int32
+	TierTotal   int32
+}
+
+// ParticipantUnit is a unit from a match participant's JSONB data.
+type ParticipantUnit struct {
+	CharacterID string
+	Name        string
+	Tier        int32 // star level
+	Rarity      int32 // cost tier (0-4 = 1-5 gold)
+	Items       []string
+}
+
+// MatchSummary is a condensed match record for history prompt building.
+type MatchSummary struct {
+	MatchID   string
+	Placement int32
+	Level     int32
+	GoldLeft  int32
+	LastRound int32
+	Augments  []string
+	Units     []ParticipantUnit
+	Traits    []ParticipantTrait
+}
+
+// HistoryAggregates holds computed stats across multiple matches.
+type HistoryAggregates struct {
+	AvgPlacement  float64
+	Top4Rate      float64
+	WinRate       float64
+	PlacementDist map[int32]int
+	TopComps      []CompFrequency
+	TopChampions  []ChampFrequency
+	TopItems      []ItemFrequency
+	TopAugments   []AugmentFrequency
+}
+
+// CompFrequency tracks how often a composition was played.
+type CompFrequency struct {
+	TraitCombo   string
+	Games        int
+	AvgPlacement float64
+}
+
+// ChampFrequency tracks how often a champion was played.
+type ChampFrequency struct {
+	Name         string
+	Games        int
+	AvgPlacement float64
+}
+
+// ItemFrequency tracks how often an item was built.
+type ItemFrequency struct {
+	Name  string
+	Count int
+}
+
+// AugmentFrequency tracks how often an augment was picked.
+type AugmentFrequency struct {
+	Name         string
+	Games        int
+	AvgPlacement float64
+}
+
+// BuildMatchCoachPrompt constructs the user prompt for per-match coaching analysis.
+func BuildMatchCoachPrompt(
+	player MatchParticipantData,
+	allParticipants []MatchParticipantData,
+	meta MatchMeta,
+	data *GameData,
+	tierList []TierListEntry,
+	playerRank string,
+) string {
+	var sb strings.Builder
+
+	// Player section
+	sb.WriteString("=== YOUR MATCH RESULT ===\n")
+	sb.WriteString(fmt.Sprintf("Placement: %d | Level: %d | Gold Left: %d | Last Round: %s\n",
+		player.Placement, player.Level, player.GoldLeft, formatRound(player.LastRound)))
+	sb.WriteString(fmt.Sprintf("Rank: %s\n", playerRank))
+	sb.WriteString(fmt.Sprintf("Damage Dealt: %d | Players Eliminated: %d\n",
+		player.TotalDamageToPlayers, player.PlayersEliminated))
+	gameLenMin := meta.GameLength / 60
+	sb.WriteString(fmt.Sprintf("Game Length: %.0fm | Game Type: %s\n", gameLenMin, meta.GameType))
+
+	if len(player.Augments) > 0 {
+		augNames := resolveAugmentNames(player.Augments, data)
+		sb.WriteString(fmt.Sprintf("\nAugments: %s\n", strings.Join(augNames, ", ")))
+	}
+
+	// Player's units
+	sb.WriteString("\nChampions:\n")
+	for i, u := range player.Units {
+		name := resolveChampionName(u.CharacterID, data)
+		cost := resolveChampionCost(u.CharacterID, data)
+		items := resolveItemNames(u.Items, data)
+		sb.WriteString(fmt.Sprintf("  %d. %s (%dg, %d*)", i+1, name, cost, u.Tier))
+		if len(items) > 0 {
+			sb.WriteString(fmt.Sprintf(" — Items: %s", strings.Join(items, ", ")))
+		}
+		sb.WriteString("\n")
+	}
+
+	// Player's active traits
+	activeTraits := filterActiveTraits(player.Traits)
+	if len(activeTraits) > 0 {
+		sb.WriteString("\nActive Traits:\n")
+		for _, t := range activeTraits {
+			name := resolveTraitName(t.ApiName, data)
+			sb.WriteString(fmt.Sprintf("  - %s: %d units (%s)\n", name, t.NumUnits, styleToName(t.Style)))
+		}
+	}
+
+	// Lobby section
+	sb.WriteString("\n=== LOBBY (all 8 players) ===\n")
+	for _, p := range allParticipants {
+		if p.Puuid == player.Puuid {
+			sb.WriteString(fmt.Sprintf("%s %d. (YOU) ", placementEmoji(p.Placement), p.Placement))
+		} else {
+			sb.WriteString(fmt.Sprintf("%s %d. ", placementEmoji(p.Placement), p.Placement))
+		}
+		// Condensed unit list (top 5 by cost)
+		sortedUnits := sortUnitsByCost(p.Units)
+		unitStrs := make([]string, 0, 5)
+		for i, u := range sortedUnits {
+			if i >= 5 {
+				break
+			}
+			name := resolveChampionName(u.CharacterID, data)
+			unitStrs = append(unitStrs, fmt.Sprintf("%s %d*", name, u.Tier))
+		}
+		sb.WriteString(strings.Join(unitStrs, ", "))
+
+		// Condensed traits
+		at := filterActiveTraits(p.Traits)
+		if len(at) > 0 {
+			traitStrs := make([]string, 0, 3)
+			for i, t := range at {
+				if i >= 3 {
+					break
+				}
+				name := resolveTraitName(t.ApiName, data)
+				traitStrs = append(traitStrs, fmt.Sprintf("%s(%d)", name, t.NumUnits))
+			}
+			sb.WriteString(" | " + strings.Join(traitStrs, " "))
+		}
+		sb.WriteString("\n")
+	}
+
+	// Meta context
+	if len(tierList) > 0 {
+		sb.WriteString("\n=== META CONTEXT (current patch) ===\n")
+		limit := 15
+		if len(tierList) < limit {
+			limit = len(tierList)
+		}
+		for _, tl := range tierList[:limit] {
+			sb.WriteString(fmt.Sprintf("%s-tier: %s", tl.Tier, tl.CompositionName))
+			if len(tl.CoreChampions) > 0 {
+				sb.WriteString(fmt.Sprintf(" (core: %s)", strings.Join(tl.CoreChampions, ", ")))
+			}
+			if tl.WinRate > 0 {
+				sb.WriteString(fmt.Sprintf(" | WR: %.0f%% | Avg: %.1f", tl.WinRate*100, tl.AvgPlacement))
+			}
+			// Show BIS for core champions
+			if len(tl.RecommendedItems) > 0 {
+				bisStrs := make([]string, 0)
+				for champ, items := range tl.RecommendedItems {
+					if len(items) > 0 {
+						bisStrs = append(bisStrs, fmt.Sprintf("%s→%s", champ, strings.Join(items, "/")))
+					}
+				}
+				if len(bisStrs) > 0 {
+					sb.WriteString(fmt.Sprintf(" | BIS: %s", strings.Join(bisStrs, ", ")))
+				}
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	sb.WriteString("\n=== INSTRUCTIONS ===\n")
+	sb.WriteString(fmt.Sprintf("Analyze this completed match. The player placed %d%s.\n",
+		player.Placement, ordinalSuffix(player.Placement)))
+	sb.WriteString("Provide insights for each category (composition, itemization, economy, augments, adaptability).\n")
+	sb.WriteString("Compare against the meta tier list. Analyze lobby context for contested comps.\n")
+	sb.WriteString("Give specific, actionable suggestions prioritized by impact.\n")
+
+	return sb.String()
+}
+
+// BuildHistoryCoachPrompt constructs the user prompt for multi-match coaching analysis.
+func BuildHistoryCoachPrompt(
+	matches []MatchSummary,
+	aggregates HistoryAggregates,
+	data *GameData,
+	tierList []TierListEntry,
+	playerRank string,
+) string {
+	var sb strings.Builder
+
+	sb.WriteString("=== PLAYER PROFILE ===\n")
+	sb.WriteString(fmt.Sprintf("Rank: %s | Matches analyzed: %d\n", playerRank, len(matches)))
+
+	// Match list
+	sb.WriteString("\n=== MATCH HISTORY ===\n")
+	for i, m := range matches {
+		sb.WriteString(fmt.Sprintf("Match %d: %s | Lv%d | %dg left | Round %s",
+			i+1, formatPlacement(m.Placement), m.Level, m.GoldLeft, formatRound(m.LastRound)))
+		// Top 3 units
+		sorted := sortUnitsByCost(m.Units)
+		unitStrs := make([]string, 0, 3)
+		for j, u := range sorted {
+			if j >= 3 {
+				break
+			}
+			name := resolveChampionName(u.CharacterID, data)
+			unitStrs = append(unitStrs, fmt.Sprintf("%s %d*", name, u.Tier))
+		}
+		if len(unitStrs) > 0 {
+			sb.WriteString(" | " + strings.Join(unitStrs, ", "))
+		}
+		// Augments
+		if len(m.Augments) > 0 {
+			augNames := resolveAugmentNames(m.Augments, data)
+			sb.WriteString(" | Aug: " + strings.Join(augNames, ", "))
+		}
+		sb.WriteString("\n")
+	}
+
+	// Aggregate stats
+	sb.WriteString("\n=== AGGREGATE STATS ===\n")
+	sb.WriteString(fmt.Sprintf("Avg Placement: %.1f | Top 4: %.0f%% | Win Rate: %.0f%%\n",
+		aggregates.AvgPlacement, aggregates.Top4Rate*100, aggregates.WinRate*100))
+	sb.WriteString("Placement Distribution: ")
+	for p := int32(1); p <= 8; p++ {
+		count := aggregates.PlacementDist[p]
+		sb.WriteString(fmt.Sprintf("%d%s=%d ", p, ordinalSuffix(p), count))
+	}
+	sb.WriteString("\n")
+
+	// Comp frequency
+	if len(aggregates.TopComps) > 0 {
+		sb.WriteString("\n=== MOST PLAYED COMPS ===\n")
+		for _, c := range aggregates.TopComps {
+			sb.WriteString(fmt.Sprintf("  %s: %d games (avg %.1f)\n", c.TraitCombo, c.Games, c.AvgPlacement))
+		}
+	}
+
+	// Champion frequency
+	if len(aggregates.TopChampions) > 0 {
+		sb.WriteString("\n=== MOST PLAYED CHAMPIONS ===\n")
+		for _, c := range aggregates.TopChampions {
+			sb.WriteString(fmt.Sprintf("  %s: %d games (avg %.1f)\n", c.Name, c.Games, c.AvgPlacement))
+		}
+	}
+
+	// Item frequency
+	if len(aggregates.TopItems) > 0 {
+		sb.WriteString("\n=== MOST BUILT ITEMS ===\n")
+		for _, it := range aggregates.TopItems {
+			sb.WriteString(fmt.Sprintf("  %s: %d times\n", it.Name, it.Count))
+		}
+	}
+
+	// Augment frequency
+	if len(aggregates.TopAugments) > 0 {
+		sb.WriteString("\n=== AUGMENT PATTERNS ===\n")
+		for _, a := range aggregates.TopAugments {
+			sb.WriteString(fmt.Sprintf("  %s: %d games (avg %.1f)\n", a.Name, a.Games, a.AvgPlacement))
+		}
+	}
+
+	// Meta context
+	if len(tierList) > 0 {
+		sb.WriteString("\n=== META CONTEXT (current patch) ===\n")
+		limit := 10
+		if len(tierList) < limit {
+			limit = len(tierList)
+		}
+		for _, tl := range tierList[:limit] {
+			sb.WriteString(fmt.Sprintf("  %s-tier: %s", tl.Tier, tl.CompositionName))
+			if tl.WinRate > 0 {
+				sb.WriteString(fmt.Sprintf(" | WR: %.0f%% | Avg: %.1f", tl.WinRate*100, tl.AvgPlacement))
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	sb.WriteString("\n=== INSTRUCTIONS ===\n")
+	sb.WriteString("Analyze this player's match history for recurring patterns.\n")
+	sb.WriteString("Rate each skill radar dimension (0-100) based on evidence.\n")
+	sb.WriteString("Identify trends by comparing first half vs second half of matches.\n")
+	sb.WriteString("Provide a concrete 3-5 step improvement plan prioritized by impact.\n")
+
+	return sb.String()
+}
+
+// ComputeHistoryAggregates computes aggregate statistics from match summaries.
+func ComputeHistoryAggregates(matches []MatchSummary, data *GameData) HistoryAggregates {
+	agg := HistoryAggregates{
+		PlacementDist: make(map[int32]int),
+	}
+
+	if len(matches) == 0 {
+		return agg
+	}
+
+	totalPlacement := 0
+	top4Count := 0
+	winCount := 0
+
+	// Track frequencies
+	champGames := make(map[string][]int32)     // name → placements
+	itemCounts := make(map[string]int)          // name → count
+	augmentGames := make(map[string][]int32)    // name → placements
+	compGames := make(map[string][]int32)       // trait combo → placements
+
+	for _, m := range matches {
+		totalPlacement += int(m.Placement)
+		agg.PlacementDist[m.Placement]++
+		if m.Placement <= 4 {
+			top4Count++
+		}
+		if m.Placement == 1 {
+			winCount++
+		}
+
+		// Champion frequency
+		for _, u := range m.Units {
+			name := resolveChampionName(u.CharacterID, data)
+			champGames[name] = append(champGames[name], m.Placement)
+
+			// Item frequency
+			for _, itemAPI := range u.Items {
+				itemName := resolveItemName(itemAPI, data)
+				itemCounts[itemName]++
+			}
+		}
+
+		// Augment frequency
+		for _, aug := range m.Augments {
+			augName := resolveItemName(aug, data) // augments are in items table
+			augmentGames[augName] = append(augmentGames[augName], m.Placement)
+		}
+
+		// Comp frequency (dominant trait combo — top 2 active traits by style)
+		combo := dominantTraitCombo(m.Traits, data)
+		if combo != "" {
+			compGames[combo] = append(compGames[combo], m.Placement)
+		}
+	}
+
+	n := float64(len(matches))
+	agg.AvgPlacement = float64(totalPlacement) / n
+	agg.Top4Rate = float64(top4Count) / n
+	agg.WinRate = float64(winCount) / n
+
+	// Build sorted frequency lists
+	agg.TopComps = buildCompFrequency(compGames, 10)
+	agg.TopChampions = buildChampFrequency(champGames, 15)
+	agg.TopItems = buildItemFrequency(itemCounts, 15)
+	agg.TopAugments = buildAugmentFrequency(augmentGames, 10)
+
+	return agg
+}
+
+// --- Helper functions ---
+
+func resolveChampionName(apiName string, data *GameData) string {
+	if data != nil {
+		if c, ok := data.Champions[apiName]; ok {
+			return c.Name
+		}
+	}
+	return apiName
+}
+
+func resolveChampionCost(apiName string, data *GameData) int32 {
+	if data != nil {
+		if c, ok := data.Champions[apiName]; ok {
+			return c.Cost
+		}
+	}
+	return 0
+}
+
+func resolveItemName(apiName string, data *GameData) string {
+	if data != nil {
+		if it, ok := data.Items[apiName]; ok {
+			return it.Name
+		}
+	}
+	return apiName
+}
+
+func resolveItemNames(apiNames []string, data *GameData) []string {
+	names := make([]string, 0, len(apiNames))
+	for _, api := range apiNames {
+		names = append(names, resolveItemName(api, data))
+	}
+	return names
+}
+
+func resolveAugmentNames(apiNames []string, data *GameData) []string {
+	// Augments are stored in the items table with "augment" tag
+	return resolveItemNames(apiNames, data)
+}
+
+func resolveTraitName(apiName string, data *GameData) string {
+	if data != nil {
+		if t, ok := data.Traits[apiName]; ok {
+			return t.Name
+		}
+	}
+	return apiName
+}
+
+func filterActiveTraits(traits []ParticipantTrait) []ParticipantTrait {
+	active := make([]ParticipantTrait, 0)
+	for _, t := range traits {
+		if t.Style > 0 {
+			active = append(active, t)
+		}
+	}
+	sort.Slice(active, func(i, j int) bool {
+		if active[i].Style != active[j].Style {
+			return active[i].Style > active[j].Style
+		}
+		return active[i].NumUnits > active[j].NumUnits
+	})
+	return active
+}
+
+func sortUnitsByCost(units []ParticipantUnit) []ParticipantUnit {
+	sorted := make([]ParticipantUnit, len(units))
+	copy(sorted, units)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Rarity != sorted[j].Rarity {
+			return sorted[i].Rarity > sorted[j].Rarity
+		}
+		return sorted[i].Tier > sorted[j].Tier
+	})
+	return sorted
+}
+
+func dominantTraitCombo(traits []ParticipantTrait, data *GameData) string {
+	active := filterActiveTraits(traits)
+	if len(active) == 0 {
+		return ""
+	}
+	limit := 2
+	if len(active) < limit {
+		limit = len(active)
+	}
+	names := make([]string, 0, limit)
+	for _, t := range active[:limit] {
+		names = append(names, resolveTraitName(t.ApiName, data))
+	}
+	return strings.Join(names, " + ")
+}
+
+func buildCompFrequency(compGames map[string][]int32, limit int) []CompFrequency {
+	result := make([]CompFrequency, 0, len(compGames))
+	for combo, placements := range compGames {
+		avg := avgPlacement(placements)
+		result = append(result, CompFrequency{TraitCombo: combo, Games: len(placements), AvgPlacement: avg})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Games > result[j].Games })
+	if len(result) > limit {
+		result = result[:limit]
+	}
+	return result
+}
+
+func buildChampFrequency(champGames map[string][]int32, limit int) []ChampFrequency {
+	result := make([]ChampFrequency, 0, len(champGames))
+	for name, placements := range champGames {
+		avg := avgPlacement(placements)
+		result = append(result, ChampFrequency{Name: name, Games: len(placements), AvgPlacement: avg})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Games > result[j].Games })
+	if len(result) > limit {
+		result = result[:limit]
+	}
+	return result
+}
+
+func buildItemFrequency(itemCounts map[string]int, limit int) []ItemFrequency {
+	result := make([]ItemFrequency, 0, len(itemCounts))
+	for name, count := range itemCounts {
+		result = append(result, ItemFrequency{Name: name, Count: count})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Count > result[j].Count })
+	if len(result) > limit {
+		result = result[:limit]
+	}
+	return result
+}
+
+func buildAugmentFrequency(augGames map[string][]int32, limit int) []AugmentFrequency {
+	result := make([]AugmentFrequency, 0, len(augGames))
+	for name, placements := range augGames {
+		avg := avgPlacement(placements)
+		result = append(result, AugmentFrequency{Name: name, Games: len(placements), AvgPlacement: avg})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Games > result[j].Games })
+	if len(result) > limit {
+		result = result[:limit]
+	}
+	return result
+}
+
+func avgPlacement(placements []int32) float64 {
+	if len(placements) == 0 {
+		return 0
+	}
+	sum := 0
+	for _, p := range placements {
+		sum += int(p)
+	}
+	return float64(sum) / float64(len(placements))
+}
+
+func formatRound(lastRound int32) string {
+	if lastRound <= 3 {
+		return fmt.Sprintf("1-%d", lastRound)
+	}
+	adjusted := lastRound - 3
+	stage := adjusted/7 + 2
+	round := adjusted%7 + 1
+	return fmt.Sprintf("%d-%d", stage, round)
+}
+
+func formatPlacement(p int32) string {
+	return fmt.Sprintf("%d%s", p, ordinalSuffix(p))
+}
+
+func ordinalSuffix(n int32) string {
+	if n >= 11 && n <= 13 {
+		return "th"
+	}
+	switch n % 10 {
+	case 1:
+		return "st"
+	case 2:
+		return "nd"
+	case 3:
+		return "rd"
+	default:
+		return "th"
+	}
+}
+
+func placementEmoji(p int32) string {
+	if p <= 4 {
+		return "+"
+	}
+	return "-"
+}

--- a/backend/internal/ai/coach_prompt_test.go
+++ b/backend/internal/ai/coach_prompt_test.go
@@ -1,0 +1,238 @@
+package ai
+
+import (
+	"strings"
+	"testing"
+)
+
+func testParticipantData(puuid string, placement int32) MatchParticipantData {
+	return MatchParticipantData{
+		Puuid:                puuid,
+		Placement:            placement,
+		Level:                8,
+		GoldLeft:             12,
+		LastRound:            35, // stage 6-4
+		TotalDamageToPlayers: 45,
+		PlayersEliminated:    1,
+		Augments:             []string{"TFT_Item_BFSword"},
+		Traits: []ParticipantTrait{
+			{ApiName: "Set13_Warrior", NumUnits: 4, Style: 2, TierCurrent: 2, TierTotal: 3},
+			{ApiName: "Set13_Rebel", NumUnits: 3, Style: 1, TierCurrent: 1, TierTotal: 2},
+		},
+		Units: []ParticipantUnit{
+			{CharacterID: "TFT13_Garen", Name: "Garen", Tier: 2, Rarity: 0, Items: []string{"TFT_Item_GuardianAngel"}},
+			{CharacterID: "TFT13_Jinx", Name: "Jinx", Tier: 2, Rarity: 2, Items: []string{"TFT_Item_InfinityEdge", "TFT_Item_BFSword"}},
+		},
+	}
+}
+
+func testTierList() []TierListEntry {
+	return []TierListEntry{
+		{
+			CompositionName:  "Warrior Garen",
+			Tier:             "S",
+			Score:            95,
+			CoreChampions:    []string{"Garen", "Vi", "Darius"},
+			RecommendedItems: map[string][]string{"Garen": {"Guardian Angel", "Warmog's"}},
+			WinRate:          0.52,
+			AvgPlacement:     3.2,
+		},
+		{
+			CompositionName: "Rebel Jinx",
+			Tier:            "A",
+			Score:           80,
+			CoreChampions:   []string{"Jinx", "Ekko"},
+			WinRate:         0.48,
+			AvgPlacement:    3.8,
+		},
+	}
+}
+
+func TestBuildMatchCoachPrompt(t *testing.T) {
+	data := testGameData()
+	player := testParticipantData("player-1", 3)
+	opponent := testParticipantData("opponent-1", 1)
+	allParticipants := []MatchParticipantData{opponent, player}
+	meta := MatchMeta{GameLength: 1800, LastRound: 35, GameType: "standard"}
+	tierList := testTierList()
+
+	prompt := BuildMatchCoachPrompt(player, allParticipants, meta, data, tierList, "Gold II")
+
+	// Should contain player section
+	if !strings.Contains(prompt, "YOUR MATCH RESULT") {
+		t.Error("prompt should contain YOUR MATCH RESULT section")
+	}
+	if !strings.Contains(prompt, "Gold II") {
+		t.Error("prompt should contain player rank")
+	}
+	if !strings.Contains(prompt, "Placement: 3") {
+		t.Error("prompt should contain placement")
+	}
+
+	// Should contain champion names (resolved from GameData)
+	if !strings.Contains(prompt, "Jinx") {
+		t.Error("prompt should contain champion name Jinx")
+	}
+	if !strings.Contains(prompt, "Garen") {
+		t.Error("prompt should contain champion name Garen")
+	}
+
+	// Should contain lobby section
+	if !strings.Contains(prompt, "LOBBY") {
+		t.Error("prompt should contain LOBBY section")
+	}
+
+	// Should contain meta context
+	if !strings.Contains(prompt, "META CONTEXT") {
+		t.Error("prompt should contain META CONTEXT section")
+	}
+	if !strings.Contains(prompt, "Warrior Garen") {
+		t.Error("prompt should contain meta comp name")
+	}
+
+	// Should contain instructions
+	if !strings.Contains(prompt, "INSTRUCTIONS") {
+		t.Error("prompt should contain INSTRUCTIONS section")
+	}
+}
+
+func TestBuildMatchCoachPrompt_NoTierList(t *testing.T) {
+	data := testGameData()
+	player := testParticipantData("player-1", 5)
+	allParticipants := []MatchParticipantData{player}
+	meta := MatchMeta{GameLength: 1500, LastRound: 30, GameType: "standard"}
+
+	prompt := BuildMatchCoachPrompt(player, allParticipants, meta, data, nil, "Silver I")
+
+	if strings.Contains(prompt, "META CONTEXT") {
+		t.Error("prompt should NOT contain META CONTEXT when tier list is empty")
+	}
+	if !strings.Contains(prompt, "YOUR MATCH RESULT") {
+		t.Error("prompt should still contain player section")
+	}
+}
+
+func TestBuildHistoryCoachPrompt(t *testing.T) {
+	data := testGameData()
+	matches := []MatchSummary{
+		{
+			MatchID: "match-1", Placement: 2, Level: 8, GoldLeft: 10, LastRound: 35,
+			Augments: []string{"TFT_Item_BFSword"},
+			Units: []ParticipantUnit{
+				{CharacterID: "TFT13_Jinx", Tier: 2, Rarity: 2, Items: []string{"TFT_Item_InfinityEdge"}},
+				{CharacterID: "TFT13_Garen", Tier: 3, Rarity: 0},
+			},
+			Traits: []ParticipantTrait{
+				{ApiName: "Set13_Warrior", NumUnits: 4, Style: 2},
+			},
+		},
+		{
+			MatchID: "match-2", Placement: 6, Level: 7, GoldLeft: 3, LastRound: 28,
+			Units: []ParticipantUnit{
+				{CharacterID: "TFT13_Garen", Tier: 2, Rarity: 0},
+			},
+			Traits: []ParticipantTrait{
+				{ApiName: "Set13_Warrior", NumUnits: 2, Style: 1},
+			},
+		},
+	}
+
+	aggregates := ComputeHistoryAggregates(matches, data)
+	prompt := BuildHistoryCoachPrompt(matches, aggregates, data, testTierList(), "Gold II")
+
+	if !strings.Contains(prompt, "PLAYER PROFILE") {
+		t.Error("prompt should contain PLAYER PROFILE section")
+	}
+	if !strings.Contains(prompt, "Matches analyzed: 2") {
+		t.Error("prompt should contain match count")
+	}
+	if !strings.Contains(prompt, "MATCH HISTORY") {
+		t.Error("prompt should contain MATCH HISTORY section")
+	}
+	if !strings.Contains(prompt, "AGGREGATE STATS") {
+		t.Error("prompt should contain AGGREGATE STATS section")
+	}
+	if !strings.Contains(prompt, "META CONTEXT") {
+		t.Error("prompt should contain META CONTEXT section")
+	}
+}
+
+func TestComputeHistoryAggregates(t *testing.T) {
+	data := testGameData()
+	matches := []MatchSummary{
+		{Placement: 1, Units: []ParticipantUnit{{CharacterID: "TFT13_Jinx", Tier: 2, Rarity: 2, Items: []string{"TFT_Item_InfinityEdge"}}}, Traits: []ParticipantTrait{{ApiName: "Set13_Rebel", NumUnits: 5, Style: 2}}},
+		{Placement: 3, Units: []ParticipantUnit{{CharacterID: "TFT13_Jinx", Tier: 2, Rarity: 2}}, Traits: []ParticipantTrait{{ApiName: "Set13_Rebel", NumUnits: 5, Style: 2}}},
+		{Placement: 5, Units: []ParticipantUnit{{CharacterID: "TFT13_Garen", Tier: 3, Rarity: 0}}, Traits: []ParticipantTrait{{ApiName: "Set13_Warrior", NumUnits: 4, Style: 2}}},
+		{Placement: 7, Units: []ParticipantUnit{{CharacterID: "TFT13_Garen", Tier: 2, Rarity: 0}}, Traits: []ParticipantTrait{{ApiName: "Set13_Warrior", NumUnits: 2, Style: 1}}},
+	}
+
+	agg := ComputeHistoryAggregates(matches, data)
+
+	// Avg placement: (1+3+5+7)/4 = 4.0
+	if agg.AvgPlacement != 4.0 {
+		t.Errorf("expected avg placement 4.0, got %.1f", agg.AvgPlacement)
+	}
+	// Top 4: 2/4 = 0.5
+	if agg.Top4Rate != 0.5 {
+		t.Errorf("expected top4 rate 0.5, got %.2f", agg.Top4Rate)
+	}
+	// Win rate: 1/4 = 0.25
+	if agg.WinRate != 0.25 {
+		t.Errorf("expected win rate 0.25, got %.2f", agg.WinRate)
+	}
+	// Placement distribution
+	if agg.PlacementDist[1] != 1 || agg.PlacementDist[3] != 1 || agg.PlacementDist[5] != 1 || agg.PlacementDist[7] != 1 {
+		t.Errorf("unexpected placement distribution: %v", agg.PlacementDist)
+	}
+	// Champion frequency: Jinx=2, Garen=2
+	if len(agg.TopChampions) < 2 {
+		t.Fatalf("expected at least 2 top champions, got %d", len(agg.TopChampions))
+	}
+	// Item frequency: Infinity Edge=1
+	if len(agg.TopItems) < 1 {
+		t.Fatalf("expected at least 1 top item, got %d", len(agg.TopItems))
+	}
+}
+
+func TestComputeHistoryAggregates_Empty(t *testing.T) {
+	data := testGameData()
+	agg := ComputeHistoryAggregates(nil, data)
+	if agg.AvgPlacement != 0 {
+		t.Errorf("expected 0 avg placement for empty matches, got %.1f", agg.AvgPlacement)
+	}
+}
+
+func TestFormatRound(t *testing.T) {
+	tests := []struct {
+		round    int32
+		expected string
+	}{
+		{1, "1-1"},
+		{3, "1-3"},
+		{4, "2-2"},
+		{10, "3-1"},
+		{35, "6-5"},
+	}
+	for _, tt := range tests {
+		got := formatRound(tt.round)
+		if got != tt.expected {
+			t.Errorf("formatRound(%d) = %q, want %q", tt.round, got, tt.expected)
+		}
+	}
+}
+
+func TestOrdinalSuffix(t *testing.T) {
+	tests := []struct {
+		n        int32
+		expected string
+	}{
+		{1, "st"}, {2, "nd"}, {3, "rd"}, {4, "th"},
+		{11, "th"}, {12, "th"}, {13, "th"}, {21, "st"},
+	}
+	for _, tt := range tests {
+		got := ordinalSuffix(tt.n)
+		if got != tt.expected {
+			t.Errorf("ordinalSuffix(%d) = %q, want %q", tt.n, got, tt.expected)
+		}
+	}
+}

--- a/backend/internal/ai/coach_schema.go
+++ b/backend/internal/ai/coach_schema.go
@@ -1,0 +1,198 @@
+package ai
+
+// CoachMatchSystemPrompt is the system message for per-match coaching analysis.
+const CoachMatchSystemPrompt = `You are an expert Teamfight Tactics (TFT) coach reviewing a completed match. Your role is to analyze the player's decisions and provide constructive, specific feedback.
+
+Rules:
+- You are reviewing a COMPLETED match — this is post-game analysis, not live coaching.
+- Analyze the player's final board: composition, itemization, augment choices, trait activations, and economy (gold left, level).
+- Compare the player's board against the current meta tier list data provided.
+- Consider the full lobby context — all 8 players' compositions. Identify if the player's comp was contested.
+- Grade each skill area honestly. Be constructive but direct — no sugarcoating.
+- Acknowledge what the player did well, not just mistakes.
+- Be SPECIFIC: use champion names, item names, trait names. Never give generic advice like "build better items".
+- The player's rank is provided — calibrate your advice accordingly. A Gold player needs different tips than a Challenger.
+- If data is missing (e.g., no tier list available), note it and analyze with what you have.
+- Infer economy decisions from final state: high gold_left = hoarding, level 7 at late game = under-leveled, etc.`
+
+// CoachHistorySystemPrompt is the system message for multi-match coaching analysis.
+const CoachHistorySystemPrompt = `You are an expert Teamfight Tactics (TFT) coach reviewing a player's recent match history to identify patterns and deliver a coaching plan.
+
+Rules:
+- You are analyzing N completed matches to find recurring habits, both good and bad.
+- Focus on PATTERNS, not individual match details — what does this player consistently do well or poorly?
+- Identify if the player is one-tricking (forcing same comp), flexing well, or forcing badly.
+- Compare their most-played compositions against meta viability.
+- Look for itemization habits: do they always build the same items? Are those items optimal?
+- Look for augment selection patterns: any bias toward certain augments?
+- Rate each skill radar dimension based on concrete evidence across matches. Cite specific numbers.
+- For trends, compare the first half of the match set vs the second half.
+- Give a concrete, prioritized 3-5 step improvement plan. Each step should be actionable in the next game.
+- The player's rank is provided — calibrate advice to their skill level.`
+
+// MatchCoachAnalysisSchema is the JSON Schema for per-match coaching structured output.
+var MatchCoachAnalysisSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"overall_grade": map[string]any{
+			"type":        "string",
+			"enum":        []string{"S+", "S", "A+", "A", "B+", "B", "C+", "C", "D", "F"},
+			"description": "Overall performance grade for this match",
+		},
+		"summary": map[string]any{
+			"type":        "string",
+			"description": "2-3 sentence coaching summary of the match performance",
+		},
+		"insights": map[string]any{
+			"type": "array",
+			"items": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"category": map[string]any{
+						"type": "string",
+						"enum": []string{"composition", "itemization", "economy", "augments", "adaptability"},
+					},
+					"title":  map[string]any{"type": "string", "description": "Short insight title"},
+					"detail": map[string]any{"type": "string", "description": "Detailed explanation with specific champion/item names"},
+					"grade": map[string]any{
+						"type": "string",
+						"enum": []string{"good", "okay", "poor"},
+					},
+				},
+				"required":             []string{"category", "title", "detail", "grade"},
+				"additionalProperties": false,
+			},
+			"description": "One insight per category (composition, itemization, economy, augments, adaptability)",
+		},
+		"meta_comparison": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"closest_meta_comp": map[string]any{"type": "string", "description": "Name of the closest meta composition"},
+				"meta_tier": map[string]any{
+					"type": "string",
+					"enum": []string{"S", "A", "B", "C", "D", "unknown"},
+				},
+				"missing_units":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Champions missing from the ideal comp"},
+				"suboptimal_items": map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Items that differ from BIS"},
+				"assessment":       map[string]any{"type": "string", "description": "How close the board was to optimal"},
+			},
+			"required":             []string{"closest_meta_comp", "meta_tier", "missing_units", "suboptimal_items", "assessment"},
+			"additionalProperties": false,
+		},
+		"lobby_context": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"contested_count":           map[string]any{"type": "integer", "description": "Number of players running similar comps"},
+				"lobby_strength_assessment": map[string]any{"type": "string", "description": "Assessment of lobby strength relative to this player"},
+				"contested_details":         map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Details on which players contested"},
+			},
+			"required":             []string{"contested_count", "lobby_strength_assessment", "contested_details"},
+			"additionalProperties": false,
+		},
+		"suggestions": map[string]any{
+			"type": "array",
+			"items": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"description": map[string]any{"type": "string"},
+					"priority": map[string]any{
+						"type": "string",
+						"enum": []string{"high", "medium", "low"},
+					},
+					"category": map[string]any{
+						"type": "string",
+						"enum": []string{"composition", "itemization", "economy", "augments", "adaptability"},
+					},
+				},
+				"required":             []string{"description", "priority", "category"},
+				"additionalProperties": false,
+			},
+			"description": "Prioritized improvement suggestions for next games",
+		},
+	},
+	"required":             []string{"overall_grade", "summary", "insights", "meta_comparison", "lobby_context", "suggestions"},
+	"additionalProperties": false,
+}
+
+// HistoryCoachAnalysisSchema is the JSON Schema for multi-match coaching structured output.
+var HistoryCoachAnalysisSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"overall_summary": map[string]any{
+			"type":        "string",
+			"description": "2-3 sentence summary of the player's recent performance patterns",
+		},
+		"skill_radar": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"economy":      map[string]any{"type": "number", "description": "Economy management rating 0-100"},
+				"itemization":  map[string]any{"type": "number", "description": "Item optimization rating 0-100"},
+				"composition":  map[string]any{"type": "number", "description": "Composition quality rating 0-100"},
+				"adaptability": map[string]any{"type": "number", "description": "Flexibility and pivoting rating 0-100"},
+				"consistency":  map[string]any{"type": "number", "description": "Placement consistency rating 0-100"},
+			},
+			"required":             []string{"economy", "itemization", "composition", "adaptability", "consistency"},
+			"additionalProperties": false,
+		},
+		"patterns": map[string]any{
+			"type": "array",
+			"items": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"category": map[string]any{
+						"type": "string",
+						"enum": []string{"composition", "itemization", "economy", "augments", "adaptability"},
+					},
+					"title":  map[string]any{"type": "string"},
+					"detail": map[string]any{"type": "string"},
+					"sentiment": map[string]any{
+						"type": "string",
+						"enum": []string{"positive", "neutral", "negative"},
+					},
+				},
+				"required":             []string{"category", "title", "detail", "sentiment"},
+				"additionalProperties": false,
+			},
+			"description": "Recurring patterns detected across matches",
+		},
+		"trends": map[string]any{
+			"type": "array",
+			"items": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"metric": map[string]any{"type": "string", "description": "What metric is trending"},
+					"direction": map[string]any{
+						"type": "string",
+						"enum": []string{"improving", "stable", "declining"},
+					},
+					"detail": map[string]any{"type": "string"},
+				},
+				"required":             []string{"metric", "direction", "detail"},
+				"additionalProperties": false,
+			},
+			"description": "Performance trends comparing first half vs second half of matches",
+		},
+		"improvement_plan": map[string]any{
+			"type": "array",
+			"items": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"description": map[string]any{"type": "string"},
+					"priority": map[string]any{
+						"type": "string",
+						"enum": []string{"high", "medium", "low"},
+					},
+					"category": map[string]any{
+						"type": "string",
+						"enum": []string{"composition", "itemization", "economy", "augments", "adaptability"},
+					},
+				},
+				"required":             []string{"description", "priority", "category"},
+				"additionalProperties": false,
+			},
+			"description": "Top 3-5 prioritized improvement actions for next games",
+		},
+	},
+	"required":             []string{"overall_summary", "skill_radar", "patterns", "trends", "improvement_plan"},
+	"additionalProperties": false,
+}

--- a/backend/internal/ai/types.go
+++ b/backend/internal/ai/types.go
@@ -56,3 +56,79 @@ type ActiveTrait struct {
 	Threshold int32 // breakpoint reached
 	Style     int32 // 0=inactive, 1=bronze, 2=silver, 3=gold, 4=chromatic
 }
+
+// --- Coach analysis types ---
+
+// MatchCoachAnalysis is the structured response for per-match coaching.
+type MatchCoachAnalysis struct {
+	OverallGrade   string            `json:"overall_grade"`
+	Summary        string            `json:"summary"`
+	Insights       []CoachingInsight `json:"insights"`
+	MetaComparison MetaComparison    `json:"meta_comparison"`
+	LobbyContext   LobbyContext      `json:"lobby_context"`
+	Suggestions    []CoachSuggestion `json:"suggestions"`
+}
+
+// CoachingInsight is a per-category coaching evaluation.
+type CoachingInsight struct {
+	Category string `json:"category"` // "composition", "itemization", "economy", "augments", "adaptability"
+	Title    string `json:"title"`
+	Detail   string `json:"detail"`
+	Grade    string `json:"grade"` // "good", "okay", "poor"
+}
+
+// MetaComparison compares the player's board against the current meta.
+type MetaComparison struct {
+	ClosestMetaComp string   `json:"closest_meta_comp"`
+	MetaTier        string   `json:"meta_tier"`
+	MissingUnits    []string `json:"missing_units"`
+	SuboptimalItems []string `json:"suboptimal_items"`
+	Assessment      string   `json:"assessment"`
+}
+
+// LobbyContext describes how contested the player's comp was in the lobby.
+type LobbyContext struct {
+	ContestedCount          int32    `json:"contested_count"`
+	LobbyStrengthAssessment string   `json:"lobby_strength_assessment"`
+	ContestedDetails        []string `json:"contested_details"`
+}
+
+// CoachSuggestion is a prioritized coaching action item.
+type CoachSuggestion struct {
+	Description string `json:"description"`
+	Priority    string `json:"priority"` // "high", "medium", "low"
+	Category    string `json:"category"` // "composition", "itemization", "economy", "augments", "adaptability"
+}
+
+// HistoryCoachAnalysis is the structured response for multi-match coaching.
+type HistoryCoachAnalysis struct {
+	OverallSummary  string            `json:"overall_summary"`
+	SkillRadar      SkillRadar        `json:"skill_radar"`
+	Patterns        []PatternInsight  `json:"patterns"`
+	Trends          []TrendItem       `json:"trends"`
+	ImprovementPlan []CoachSuggestion `json:"improvement_plan"`
+}
+
+// SkillRadar rates 5 skill dimensions from 0 to 100.
+type SkillRadar struct {
+	Economy      float64 `json:"economy"`
+	Itemization  float64 `json:"itemization"`
+	Composition  float64 `json:"composition"`
+	Adaptability float64 `json:"adaptability"`
+	Consistency  float64 `json:"consistency"`
+}
+
+// PatternInsight describes a recurring pattern across matches.
+type PatternInsight struct {
+	Category  string `json:"category"`
+	Title     string `json:"title"`
+	Detail    string `json:"detail"`
+	Sentiment string `json:"sentiment"` // "positive", "neutral", "negative"
+}
+
+// TrendItem describes a performance trend direction.
+type TrendItem struct {
+	Metric    string `json:"metric"`
+	Direction string `json:"direction"` // "improving", "stable", "declining"
+	Detail    string `json:"detail"`
+}

--- a/backend/internal/coach/mapper.go
+++ b/backend/internal/coach/mapper.go
@@ -1,0 +1,224 @@
+package coach
+
+import (
+	"encoding/json"
+	"math/big"
+
+	tftv1 "github.com/MeninoNias/tft-oracle/backend/gen/tft/v1"
+	"github.com/MeninoNias/tft-oracle/backend/internal/ai"
+	"github.com/MeninoNias/tft-oracle/backend/sqlc/generated"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// --- AI response → Proto ---
+
+func mapMatchAnalysisToProto(matchID string, placement int32, a *ai.MatchCoachAnalysis) *tftv1.AnalyzeMatchResponse {
+	insights := make([]*tftv1.CoachingInsight, 0, len(a.Insights))
+	for _, ins := range a.Insights {
+		insights = append(insights, &tftv1.CoachingInsight{
+			Category: ins.Category,
+			Title:    ins.Title,
+			Detail:   ins.Detail,
+			Grade:    ins.Grade,
+		})
+	}
+
+	suggestions := make([]*tftv1.CoachSuggestion, 0, len(a.Suggestions))
+	for _, s := range a.Suggestions {
+		suggestions = append(suggestions, &tftv1.CoachSuggestion{
+			Description: s.Description,
+			Priority:    s.Priority,
+			Category:    s.Category,
+		})
+	}
+
+	return &tftv1.AnalyzeMatchResponse{
+		MatchId:      matchID,
+		Placement:    placement,
+		OverallGrade: a.OverallGrade,
+		Summary:      a.Summary,
+		Insights:     insights,
+		MetaComparison: &tftv1.MetaComparison{
+			ClosestMetaComp: a.MetaComparison.ClosestMetaComp,
+			MetaTier:        a.MetaComparison.MetaTier,
+			MissingUnits:    a.MetaComparison.MissingUnits,
+			SuboptimalItems: a.MetaComparison.SuboptimalItems,
+			Assessment:      a.MetaComparison.Assessment,
+		},
+		LobbyContext: &tftv1.LobbyContext{
+			ContestedCount:          a.LobbyContext.ContestedCount,
+			LobbyStrengthAssessment: a.LobbyContext.LobbyStrengthAssessment,
+			ContestedDetails:        a.LobbyContext.ContestedDetails,
+		},
+		Suggestions: suggestions,
+	}
+}
+
+func mapHistoryAnalysisToProto(matchCount int32, a *ai.HistoryCoachAnalysis) *tftv1.AnalyzeHistoryResponse {
+	patterns := make([]*tftv1.PatternInsight, 0, len(a.Patterns))
+	for _, p := range a.Patterns {
+		patterns = append(patterns, &tftv1.PatternInsight{
+			Category:  p.Category,
+			Title:     p.Title,
+			Detail:    p.Detail,
+			Sentiment: p.Sentiment,
+		})
+	}
+
+	trends := make([]*tftv1.TrendItem, 0, len(a.Trends))
+	for _, t := range a.Trends {
+		trends = append(trends, &tftv1.TrendItem{
+			Metric:    t.Metric,
+			Direction: t.Direction,
+			Detail:    t.Detail,
+		})
+	}
+
+	plan := make([]*tftv1.CoachSuggestion, 0, len(a.ImprovementPlan))
+	for _, s := range a.ImprovementPlan {
+		plan = append(plan, &tftv1.CoachSuggestion{
+			Description: s.Description,
+			Priority:    s.Priority,
+			Category:    s.Category,
+		})
+	}
+
+	return &tftv1.AnalyzeHistoryResponse{
+		MatchesAnalyzed: matchCount,
+		OverallSummary:  a.OverallSummary,
+		SkillRadar: &tftv1.SkillRadar{
+			Economy:      float32(a.SkillRadar.Economy),
+			Itemization:  float32(a.SkillRadar.Itemization),
+			Composition:  float32(a.SkillRadar.Composition),
+			Adaptability: float32(a.SkillRadar.Adaptability),
+			Consistency:  float32(a.SkillRadar.Consistency),
+		},
+		Patterns:        patterns,
+		Trends:          trends,
+		ImprovementPlan: plan,
+	}
+}
+
+// --- DB → AI types ---
+
+// dbTrait mirrors the JSONB structure stored in match_participants.traits.
+type dbTrait struct {
+	Name        string `json:"name"`
+	NumUnits    int32  `json:"num_units"`
+	Style       int32  `json:"style"`
+	TierCurrent int32  `json:"tier_current"`
+	TierTotal   int32  `json:"tier_total"`
+}
+
+// dbUnit mirrors the JSONB structure stored in match_participants.units.
+type dbUnit struct {
+	CharacterID string   `json:"character_id"`
+	Name        string   `json:"name"`
+	Tier        int32    `json:"tier"`
+	Rarity      int32    `json:"rarity"`
+	Items       []string `json:"items"`
+}
+
+func mapParticipantToCoachData(p generated.MatchParticipant) ai.MatchParticipantData {
+	var traits []dbTrait
+	_ = json.Unmarshal(p.Traits, &traits)
+
+	var units []dbUnit
+	_ = json.Unmarshal(p.Units, &units)
+
+	aiTraits := make([]ai.ParticipantTrait, 0, len(traits))
+	for _, t := range traits {
+		aiTraits = append(aiTraits, ai.ParticipantTrait{
+			ApiName:     t.Name, // stored as trait name/apiName in JSONB
+			NumUnits:    t.NumUnits,
+			Style:       t.Style,
+			TierCurrent: t.TierCurrent,
+			TierTotal:   t.TierTotal,
+		})
+	}
+
+	aiUnits := make([]ai.ParticipantUnit, 0, len(units))
+	for _, u := range units {
+		aiUnits = append(aiUnits, ai.ParticipantUnit{
+			CharacterID: u.CharacterID,
+			Name:        u.Name,
+			Tier:        u.Tier,
+			Rarity:      u.Rarity,
+			Items:       u.Items,
+		})
+	}
+
+	return ai.MatchParticipantData{
+		Puuid:                p.Puuid,
+		Placement:            p.Placement,
+		Level:                p.Level,
+		GoldLeft:             p.GoldLeft,
+		LastRound:            p.LastRound,
+		TimeEliminated:       p.TimeEliminated,
+		TotalDamageToPlayers: p.TotalDamageToPlayers,
+		PlayersEliminated:    p.PlayersEliminated,
+		Augments:             p.Augments,
+		Traits:               aiTraits,
+		Units:                aiUnits,
+	}
+}
+
+func mapParticipantToSummary(p generated.MatchParticipant) ai.MatchSummary {
+	data := mapParticipantToCoachData(p)
+	return ai.MatchSummary{
+		MatchID:   p.MatchID,
+		Placement: data.Placement,
+		Level:     data.Level,
+		GoldLeft:  data.GoldLeft,
+		LastRound: data.LastRound,
+		Augments:  data.Augments,
+		Units:     data.Units,
+		Traits:    data.Traits,
+	}
+}
+
+// --- Tier list DB → AI types ---
+
+func mapTierListForPrompt(entries []generated.ConsolidatedTierList) []ai.TierListEntry {
+	result := make([]ai.TierListEntry, 0, len(entries))
+	for _, e := range entries {
+		entry := ai.TierListEntry{
+			CompositionName: e.CompositionName,
+			Tier:            e.ConsolidatedTier,
+			Score:           numericToFloat(e.ConsolidatedScore),
+			CoreChampions:   e.CoreChampions,
+			WinRate:         numericToFloat(e.AvgWinRate),
+			AvgPlacement:    numericToFloat(e.AvgPlacement),
+		}
+
+		// Decode recommended items JSONB
+		if len(e.RecommendedItems) > 0 {
+			var items map[string][]string
+			if err := json.Unmarshal(e.RecommendedItems, &items); err == nil {
+				entry.RecommendedItems = items
+			}
+		}
+
+		result = append(result, entry)
+	}
+	return result
+}
+
+func numericToFloat(n pgtype.Numeric) float64 {
+	if !n.Valid {
+		return 0
+	}
+	f, _ := n.Int.Float64()
+	if n.Exp != 0 {
+		// Adjust for exponent
+		exp := new(big.Float).SetFloat64(1)
+		for i := int32(0); i < -n.Exp; i++ {
+			exp.Mul(exp, new(big.Float).SetFloat64(10))
+		}
+		result := new(big.Float).SetFloat64(f)
+		result.Quo(result, exp)
+		r, _ := result.Float64()
+		return r
+	}
+	return f
+}

--- a/backend/internal/coach/service.go
+++ b/backend/internal/coach/service.go
@@ -1,0 +1,411 @@
+package coach
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"connectrpc.com/connect"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	tftv1 "github.com/MeninoNias/tft-oracle/backend/gen/tft/v1"
+	"github.com/MeninoNias/tft-oracle/backend/gen/tft/v1/tftv1connect"
+	"github.com/MeninoNias/tft-oracle/backend/internal/ai"
+	"github.com/MeninoNias/tft-oracle/backend/internal/auth"
+	"github.com/MeninoNias/tft-oracle/backend/sqlc/generated"
+)
+
+var _ tftv1connect.CoachServiceHandler = (*Service)(nil)
+
+type Service struct {
+	db      *pgxpool.Pool
+	queries *generated.Queries
+	ai      *ai.Client
+}
+
+func NewService(db *pgxpool.Pool, aiClient *ai.Client) *Service {
+	return &Service{
+		db:      db,
+		queries: generated.New(db),
+		ai:      aiClient,
+	}
+}
+
+// GetMatchAnalysis returns a previously cached analysis without calling AI.
+func (s *Service) GetMatchAnalysis(
+	ctx context.Context,
+	req *connect.Request[tftv1.GetMatchAnalysisRequest],
+) (*connect.Response[tftv1.GetMatchAnalysisResponse], error) {
+	if _, err := auth.RequireAuth(ctx); err != nil {
+		return nil, err
+	}
+
+	matchID := req.Msg.MatchId
+	puuid := req.Msg.Puuid
+	if matchID == "" || puuid == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("match_id and puuid are required"))
+	}
+
+	cached, err := s.queries.GetCoachMatchAnalysis(ctx, generated.GetCoachMatchAnalysisParams{
+		MatchID: matchID,
+		Puuid:   puuid,
+	})
+	if err != nil {
+		return connect.NewResponse(&tftv1.GetMatchAnalysisResponse{Found: false}), nil
+	}
+
+	var analysis ai.MatchCoachAnalysis
+	if err := json.Unmarshal(cached.Response, &analysis); err != nil {
+		return connect.NewResponse(&tftv1.GetMatchAnalysisResponse{Found: false}), nil
+	}
+
+	placement := s.getPlayerPlacement(ctx, matchID, puuid)
+	return connect.NewResponse(&tftv1.GetMatchAnalysisResponse{
+		Found:    true,
+		Analysis: mapMatchAnalysisToProto(matchID, placement, &analysis),
+	}), nil
+}
+
+// AnalyzeMatch delivers personalized coaching for a single completed match.
+func (s *Service) AnalyzeMatch(
+	ctx context.Context,
+	req *connect.Request[tftv1.AnalyzeMatchRequest],
+) (*connect.Response[tftv1.AnalyzeMatchResponse], error) {
+	// Require authentication
+	if _, err := auth.RequireAuth(ctx); err != nil {
+		return nil, err
+	}
+
+	matchID := req.Msg.MatchId
+	puuid := req.Msg.Puuid
+
+	if matchID == "" || puuid == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("match_id and puuid are required"))
+	}
+
+	if !s.ai.Available() {
+		return nil, connect.NewError(connect.CodeUnavailable,
+			fmt.Errorf("AI coaching is not available — OPENAI_API_KEY not configured"))
+	}
+
+	// Check cache (skip if force re-generation requested)
+	if !req.Msg.Force {
+		cached, err := s.queries.GetCoachMatchAnalysis(ctx, generated.GetCoachMatchAnalysisParams{
+			MatchID: matchID,
+			Puuid:   puuid,
+		})
+		if err == nil {
+			var analysis ai.MatchCoachAnalysis
+			if err := json.Unmarshal(cached.Response, &analysis); err == nil {
+				log.Printf("coach-match: cache hit for %s/%s", matchID, puuid[:8])
+				placement := s.getPlayerPlacement(ctx, matchID, puuid)
+				return connect.NewResponse(mapMatchAnalysisToProto(matchID, placement, &analysis)), nil
+			}
+		}
+	}
+
+	// Load match data
+	participants, err := s.queries.GetParticipantsByMatch(ctx, matchID)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound,
+			fmt.Errorf("match not found: %w", err))
+	}
+
+	// Find the player
+	var playerData ai.MatchParticipantData
+	var allData []ai.MatchParticipantData
+	found := false
+	for _, p := range participants {
+		d := mapParticipantToCoachData(p)
+		allData = append(allData, d)
+		if p.Puuid == puuid {
+			playerData = d
+			found = true
+		}
+	}
+	if !found {
+		return nil, connect.NewError(connect.CodeNotFound,
+			fmt.Errorf("player %s not found in match %s", puuid, matchID))
+	}
+
+	// Load match metadata
+	match, err := s.queries.GetMatchByID(ctx, matchID)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal,
+			fmt.Errorf("load match metadata: %w", err))
+	}
+	meta := ai.MatchMeta{
+		GameLength: match.GameLength,
+		LastRound:  playerData.LastRound,
+		GameType:   match.TftGameType,
+	}
+
+	// Load enrichment data
+	gameData, err := s.loadGameData(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal,
+			fmt.Errorf("load game data: %w", err))
+	}
+
+	tierList := s.loadTierList(ctx)
+	playerRank := s.loadPlayerRank(ctx, puuid)
+
+	// Build prompt and call AI
+	prompt := ai.BuildMatchCoachPrompt(playerData, allData, meta, gameData, tierList, playerRank)
+	analysis, tokensUsed, err := s.ai.AnalyzeMatchCoaching(ctx, prompt)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal,
+			fmt.Errorf("ai analysis: %w", err))
+	}
+
+	// Cache result
+	responseJSON, _ := json.Marshal(analysis)
+	_, cacheErr := s.queries.UpsertCoachMatchAnalysis(ctx, generated.UpsertCoachMatchAnalysisParams{
+		MatchID:    matchID,
+		Puuid:      puuid,
+		Response:   responseJSON,
+		Model:      "gpt-4o-mini",
+		TokensUsed: int32(tokensUsed),
+	})
+	if cacheErr != nil {
+		log.Printf("warning: failed to cache coach match analysis: %v", cacheErr)
+	}
+
+	return connect.NewResponse(mapMatchAnalysisToProto(matchID, playerData.Placement, analysis)), nil
+}
+
+// AnalyzeHistory identifies patterns and trends across recent matches.
+func (s *Service) AnalyzeHistory(
+	ctx context.Context,
+	req *connect.Request[tftv1.AnalyzeHistoryRequest],
+) (*connect.Response[tftv1.AnalyzeHistoryResponse], error) {
+	// Require authentication
+	if _, err := auth.RequireAuth(ctx); err != nil {
+		return nil, err
+	}
+
+	puuid := req.Msg.Puuid
+	matchCount := req.Msg.MatchCount
+
+	if puuid == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("puuid is required"))
+	}
+
+	if !s.ai.Available() {
+		return nil, connect.NewError(connect.CodeUnavailable,
+			fmt.Errorf("AI coaching is not available — OPENAI_API_KEY not configured"))
+	}
+
+	// Default and cap match count
+	if matchCount <= 0 {
+		matchCount = 20
+	}
+	if matchCount > 50 {
+		matchCount = 50
+	}
+
+	// Load participant rows
+	participantRows, err := s.queries.GetParticipantsByPUUID(ctx, generated.GetParticipantsByPUUIDParams{
+		Puuid:  puuid,
+		Limit:  matchCount,
+		Offset: 0,
+	})
+	if err != nil || len(participantRows) == 0 {
+		return nil, connect.NewError(connect.CodeNotFound,
+			fmt.Errorf("no matches found for player"))
+	}
+
+	actualCount := int32(len(participantRows))
+
+	// Build match IDs for cache key
+	matchIDs := make([]string, 0, len(participantRows))
+	for _, p := range participantRows {
+		matchIDs = append(matchIDs, p.MatchID)
+	}
+
+	// Check cache
+	cached, err := s.queries.GetCoachHistoryAnalysis(ctx, generated.GetCoachHistoryAnalysisParams{
+		Puuid:      puuid,
+		MatchCount: actualCount,
+	})
+	if err == nil && matchIDsMatch(cached.MatchIds, matchIDs) {
+		var analysis ai.HistoryCoachAnalysis
+		if err := json.Unmarshal(cached.Response, &analysis); err == nil {
+			log.Printf("coach-history: cache hit for %s (n=%d)", puuid[:8], actualCount)
+			return connect.NewResponse(mapHistoryAnalysisToProto(actualCount, &analysis)), nil
+		}
+	}
+
+	// Build match summaries
+	summaries := make([]ai.MatchSummary, 0, len(participantRows))
+	for _, p := range participantRows {
+		summaries = append(summaries, mapParticipantToSummary(p))
+	}
+
+	// Load enrichment data
+	gameData, err := s.loadGameData(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal,
+			fmt.Errorf("load game data: %w", err))
+	}
+
+	aggregates := ai.ComputeHistoryAggregates(summaries, gameData)
+	tierList := s.loadTierList(ctx)
+	playerRank := s.loadPlayerRank(ctx, puuid)
+
+	// Build prompt and call AI
+	prompt := ai.BuildHistoryCoachPrompt(summaries, aggregates, gameData, tierList, playerRank)
+	analysis, tokensUsed, err := s.ai.AnalyzeHistoryCoaching(ctx, prompt)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal,
+			fmt.Errorf("ai analysis: %w", err))
+	}
+
+	// Cache result
+	responseJSON, _ := json.Marshal(analysis)
+	_, cacheErr := s.queries.UpsertCoachHistoryAnalysis(ctx, generated.UpsertCoachHistoryAnalysisParams{
+		Puuid:      puuid,
+		MatchCount: actualCount,
+		MatchIds:   matchIDs,
+		Response:   responseJSON,
+		Model:      "gpt-4o-mini",
+		TokensUsed: int32(tokensUsed),
+	})
+	if cacheErr != nil {
+		log.Printf("warning: failed to cache coach history analysis: %v", cacheErr)
+	}
+
+	return connect.NewResponse(mapHistoryAnalysisToProto(actualCount, analysis)), nil
+}
+
+// --- Internal helpers ---
+
+func (s *Service) loadGameData(ctx context.Context) (*ai.GameData, error) {
+	set, err := s.queries.GetLatestSet(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get latest set: %w", err)
+	}
+
+	champions, err := s.queries.GetChampionsBySet(ctx, set.Number)
+	if err != nil {
+		return nil, fmt.Errorf("get champions: %w", err)
+	}
+
+	items, err := s.queries.GetItemsBySet(ctx, set.Number)
+	if err != nil {
+		return nil, fmt.Errorf("get items: %w", err)
+	}
+
+	traits, err := s.queries.GetTraitsBySet(ctx, set.Number)
+	if err != nil {
+		return nil, fmt.Errorf("get traits: %w", err)
+	}
+
+	// Also load augments (items with "augment" tag)
+	augments, err := s.queries.GetAugmentsBySet(ctx, set.Number)
+	if err != nil {
+		// Not critical — augments are optional
+		log.Printf("warning: failed to load augments: %v", err)
+	}
+
+	data := &ai.GameData{
+		Champions:      make(map[string]*tftv1.Champion, len(champions)),
+		Items:          make(map[string]*tftv1.Item, len(items)+len(augments)),
+		Traits:         make(map[string]*tftv1.Trait, len(traits)),
+		ChampionTraits: make(map[string][]string),
+	}
+
+	for _, c := range champions {
+		data.Champions[c.ApiName] = &tftv1.Champion{
+			ApiName: c.ApiName,
+			Name:    c.Name,
+			Cost:    c.Cost,
+		}
+
+		ct, err := s.queries.GetTraitsByChampion(ctx, generated.GetTraitsByChampionParams{
+			ChampionApiName: c.ApiName,
+			SetNumber:       set.Number,
+		})
+		if err == nil {
+			traitNames := make([]string, 0, len(ct))
+			for _, t := range ct {
+				traitNames = append(traitNames, t.TraitApiName)
+			}
+			data.ChampionTraits[c.ApiName] = traitNames
+		}
+	}
+
+	for _, i := range items {
+		data.Items[i.ApiName] = &tftv1.Item{ApiName: i.ApiName, Name: i.Name}
+	}
+	for _, a := range augments {
+		data.Items[a.ApiName] = &tftv1.Item{ApiName: a.ApiName, Name: a.Name}
+	}
+
+	for _, t := range traits {
+		data.Traits[t.ApiName] = &tftv1.Trait{
+			ApiName: t.ApiName,
+			Name:    t.Name,
+		}
+	}
+
+	return data, nil
+}
+
+func (s *Service) loadTierList(ctx context.Context) []ai.TierListEntry {
+	patch, err := s.queries.GetLatestConsolidatedPatch(ctx)
+	if err != nil {
+		return nil
+	}
+
+	entries, err := s.queries.GetConsolidatedTierList(ctx, patch)
+	if err != nil {
+		return nil
+	}
+
+	return mapTierListForPrompt(entries)
+}
+
+func (s *Service) loadPlayerRank(ctx context.Context, puuid string) string {
+	player, err := s.queries.GetPlayerByPUUID(ctx, puuid)
+	if err != nil {
+		return "Unknown"
+	}
+	if player.Tier == "" {
+		return "Unranked"
+	}
+	return fmt.Sprintf("%s %s", player.Tier, player.Rank)
+}
+
+func (s *Service) getPlayerPlacement(ctx context.Context, matchID, puuid string) int32 {
+	participants, err := s.queries.GetParticipantsByMatch(ctx, matchID)
+	if err != nil {
+		return 0
+	}
+	for _, p := range participants {
+		if p.Puuid == puuid {
+			return p.Placement
+		}
+	}
+	return 0
+}
+
+func matchIDsMatch(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Ensure pgx.ErrNoRows is handled (used by cache checks).
+var _ = pgx.ErrNoRows

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -22,6 +22,10 @@ type Config struct {
 	// Auth
 	JWTSecret string
 	JWTExpiry string // duration string, e.g. "720h" for 30 days
+
+	// Phase 4: Crawler
+	CrawlerInterval string // duration string, e.g. "24h"
+	CrawlerEnabled  bool
 }
 
 func Load() (*Config, error) {
@@ -34,8 +38,10 @@ func Load() (*Config, error) {
 		RiotAPIKey:  getEnv("RIOT_API_KEY", ""),
 		RedisURL:    getEnv("REDIS_URL", "redis://localhost:6379"),
 		OpenAIAPIKey: getEnv("OPENAI_API_KEY", ""),
-		JWTSecret:    getEnv("JWT_SECRET", ""),
-		JWTExpiry:   getEnv("JWT_EXPIRY", "720h"),
+		JWTSecret:       getEnv("JWT_SECRET", ""),
+		JWTExpiry:       getEnv("JWT_EXPIRY", "720h"),
+		CrawlerInterval: getEnv("CRAWLER_INTERVAL", "24h"),
+		CrawlerEnabled:  getEnv("CRAWLER_ENABLED", "true") == "true",
 	}
 
 	if cfg.DatabaseURL == "" {

--- a/backend/internal/consolidation/engine.go
+++ b/backend/internal/consolidation/engine.go
@@ -1,0 +1,159 @@
+package consolidation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/big"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/MeninoNias/tft-oracle/backend/sqlc/generated"
+)
+
+// Engine consolidates raw tier data from multiple sources into a unified tier list.
+type Engine struct {
+	db      *pgxpool.Pool
+	queries *generated.Queries
+	weights map[string]float64
+}
+
+// NewEngine creates a new consolidation engine.
+func NewEngine(db *pgxpool.Pool, weights map[string]float64) *Engine {
+	if weights == nil {
+		weights = DefaultWeights
+	}
+	return &Engine{
+		db:      db,
+		queries: generated.New(db),
+		weights: weights,
+	}
+}
+
+// Consolidate fetches raw tier data for a patch, matches compositions,
+// scores them, and stores the results.
+func (e *Engine) Consolidate(ctx context.Context, patch string) error {
+	log.Printf("consolidation: processing patch %s...", patch)
+
+	// 1. Fetch all raw data for this patch
+	rawData, err := e.queries.GetRawTierDataByPatch(ctx, patch)
+	if err != nil {
+		return fmt.Errorf("fetch raw data: %w", err)
+	}
+
+	if len(rawData) == 0 {
+		log.Printf("consolidation: no raw data for patch %s", patch)
+		return nil
+	}
+
+	// 2. Group by source and normalize
+	bySource := make(map[string][]NormalizedComp)
+	for _, row := range rawData {
+		comp := NormalizedComp{
+			Source:      row.Source,
+			Name:        row.CompositionName,
+			Tier:        textToString(row.Tier),
+			Score:       TierToScore[textToString(row.Tier)],
+			WinRate:     numericToFloat(row.WinRate),
+			PlayRate:    numericToFloat(row.PlayRate),
+			AvgPlacement: numericToFloat(row.AvgPlacement),
+			ChampionIDs: row.ChampionIds,
+		}
+
+		// Parse core items from JSONB
+		if len(row.CoreItems) > 0 {
+			var items map[string][]string
+			if err := json.Unmarshal(row.CoreItems, &items); err == nil {
+				comp.CoreItems = items
+			}
+		}
+		if comp.CoreItems == nil {
+			comp.CoreItems = make(map[string][]string)
+		}
+
+		bySource[row.Source] = append(bySource[row.Source], comp)
+	}
+
+	// 3. Match compositions across sources
+	groups := MatchCompositions(bySource)
+	log.Printf("consolidation: matched %d raw entries into %d composition groups", len(rawData), len(groups))
+
+	// 4. Score each group
+	results := make([]ConsolidatedResult, 0, len(groups))
+	for _, group := range groups {
+		result := ScoreGroup(group, e.weights)
+		results = append(results, result)
+	}
+
+	// 5. Store consolidated results
+	for _, r := range results {
+		itemsJSON, err := json.Marshal(r.RecommendedItems)
+		if err != nil {
+			return fmt.Errorf("marshal items for %q: %w", r.Name, err)
+		}
+
+		champions := r.CoreChampions
+		if champions == nil {
+			champions = []string{}
+		}
+
+		_, err = e.queries.UpsertConsolidatedTierEntry(ctx, generated.UpsertConsolidatedTierEntryParams{
+			Patch:             patch,
+			CompositionName:   r.Name,
+			ConsolidatedTier:  r.ConsolidatedTier,
+			ConsolidatedScore: floatToNumeric(r.ConsolidatedScore),
+			Confidence:        r.Confidence,
+			Consensus:         r.Consensus,
+			MetatftTier:       stringToText(r.MetaTFTTier),
+			TftacticsTier:     stringToText(r.TFTacticsTier),
+			MobalyticsTier:    stringToText(r.MobalyticsTier),
+			AvgWinRate:        floatToNumeric(r.AvgWinRate),
+			AvgPlayRate:       floatToNumeric(r.AvgPlayRate),
+			AvgPlacement:      floatToNumeric(r.AvgPlacement),
+			CoreChampions:     champions,
+			RecommendedItems:  itemsJSON,
+		})
+		if err != nil {
+			return fmt.Errorf("upsert consolidated %q: %w", r.Name, err)
+		}
+	}
+
+	log.Printf("consolidation: stored %d consolidated compositions for patch %s", len(results), patch)
+	return nil
+}
+
+func textToString(t pgtype.Text) string {
+	if !t.Valid {
+		return ""
+	}
+	return t.String
+}
+
+func numericToFloat(n pgtype.Numeric) float64 {
+	if !n.Valid || n.Int == nil {
+		return 0
+	}
+	f, _ := n.Float64Value()
+	return f.Float64
+}
+
+func stringToText(s string) pgtype.Text {
+	if s == "" {
+		return pgtype.Text{Valid: false}
+	}
+	return pgtype.Text{String: s, Valid: true}
+}
+
+func floatToNumeric(f float64) pgtype.Numeric {
+	if f == 0 {
+		return pgtype.Numeric{Valid: false}
+	}
+	scaled := int64(f * 100)
+	return pgtype.Numeric{
+		Int:   big.NewInt(scaled),
+		Exp:   -2,
+		Valid: true,
+	}
+}

--- a/backend/internal/consolidation/matcher.go
+++ b/backend/internal/consolidation/matcher.go
@@ -1,0 +1,113 @@
+package consolidation
+
+// JaccardSimilarity computes the Jaccard coefficient between two string slices.
+// Returns a value between 0.0 (no overlap) and 1.0 (identical).
+func JaccardSimilarity(a, b []string) float64 {
+	if len(a) == 0 && len(b) == 0 {
+		return 0
+	}
+
+	setA := make(map[string]struct{}, len(a))
+	for _, v := range a {
+		setA[v] = struct{}{}
+	}
+
+	setB := make(map[string]struct{}, len(b))
+	for _, v := range b {
+		setB[v] = struct{}{}
+	}
+
+	intersection := 0
+	for k := range setA {
+		if _, ok := setB[k]; ok {
+			intersection++
+		}
+	}
+
+	// Union = |A| + |B| - |A ∩ B|
+	union := len(setA) + len(setB) - intersection
+	if union == 0 {
+		return 0
+	}
+
+	return float64(intersection) / float64(union)
+}
+
+const matchThreshold = 0.8
+
+// MatchCompositions groups compositions from multiple sources by champion overlap.
+// Compositions with >= 80% Jaccard similarity are considered the same comp.
+func MatchCompositions(bySource map[string][]NormalizedComp) []MatchGroup {
+	var groups []MatchGroup
+
+	// Process each source in a deterministic order
+	sourceOrder := []string{"mobalytics", "tacticstools", "metatft"}
+
+	for _, source := range sourceOrder {
+		comps, ok := bySource[source]
+		if !ok {
+			continue
+		}
+
+		for _, comp := range comps {
+			bestIdx := -1
+			bestSim := 0.0
+
+			for i, group := range groups {
+				sim := JaccardSimilarity(comp.ChampionIDs, group.ChampionIDs)
+				if sim >= matchThreshold && sim > bestSim {
+					bestIdx = i
+					bestSim = sim
+				}
+			}
+
+			if bestIdx >= 0 {
+				// Add to existing group
+				groups[bestIdx].Sources = append(groups[bestIdx].Sources, comp)
+				// Merge champion IDs (union)
+				groups[bestIdx].ChampionIDs = unionStrings(groups[bestIdx].ChampionIDs, comp.ChampionIDs)
+				// Merge core items
+				for k, v := range comp.CoreItems {
+					if _, exists := groups[bestIdx].CoreItems[k]; !exists {
+						groups[bestIdx].CoreItems[k] = v
+					}
+				}
+			} else {
+				// Create new group
+				items := make(map[string][]string)
+				for k, v := range comp.CoreItems {
+					items[k] = v
+				}
+				groups = append(groups, MatchGroup{
+					Name:        comp.Name,
+					Sources:     []NormalizedComp{comp},
+					ChampionIDs: append([]string{}, comp.ChampionIDs...),
+					CoreItems:   items,
+				})
+			}
+		}
+	}
+
+	return groups
+}
+
+// unionStrings returns the union of two string slices with no duplicates.
+func unionStrings(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	var result []string
+
+	for _, v := range a {
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			result = append(result, v)
+		}
+	}
+	for _, v := range b {
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			result = append(result, v)
+		}
+	}
+
+	return result
+}

--- a/backend/internal/consolidation/scorer.go
+++ b/backend/internal/consolidation/scorer.go
@@ -1,0 +1,174 @@
+package consolidation
+
+import "math"
+
+// TierToScore converts a letter tier to a numeric score (0-100).
+var TierToScore = map[string]float64{
+	"S": 95,
+	"A": 80,
+	"B": 60,
+	"C": 40,
+	"D": 20,
+}
+
+// ScoreToTier converts a numeric score back to a letter tier.
+func ScoreToTier(score float64) string {
+	switch {
+	case score >= 88:
+		return "S"
+	case score >= 70:
+		return "A"
+	case score >= 50:
+		return "B"
+	case score >= 30:
+		return "C"
+	default:
+		return "D"
+	}
+}
+
+// DefaultWeights are the source weights for cross-ranking.
+var DefaultWeights = map[string]float64{
+	"mobalytics":   0.50,
+	"tacticstools": 0.35,
+	"metatft":      0.15,
+}
+
+// ScoreGroup computes the consolidated result for a match group.
+func ScoreGroup(group MatchGroup, weights map[string]float64) ConsolidatedResult {
+	if weights == nil {
+		weights = DefaultWeights
+	}
+
+	// Collect per-source data
+	tiers := make(map[string]string)       // source -> tier
+	scores := make(map[string]float64)     // source -> numeric score
+	winRates := make([]float64, 0)
+	playRates := make([]float64, 0)
+	placements := make([]float64, 0)
+
+	for _, src := range group.Sources {
+		tiers[src.Source] = src.Tier
+		scores[src.Source] = TierToScore[src.Tier]
+
+		if src.WinRate > 0 {
+			winRates = append(winRates, src.WinRate)
+		}
+		if src.PlayRate > 0 {
+			playRates = append(playRates, src.PlayRate)
+		}
+		if src.AvgPlacement > 0 {
+			placements = append(placements, src.AvgPlacement)
+		}
+	}
+
+	// Weighted score
+	totalWeight := 0.0
+	weightedScore := 0.0
+	for source, score := range scores {
+		w := weights[source]
+		if w == 0 {
+			w = 1.0 / float64(len(scores))
+		}
+		weightedScore += score * w
+		totalWeight += w
+	}
+	if totalWeight > 0 {
+		weightedScore /= totalWeight
+	}
+
+	// Confidence and consensus
+	confidence := computeConfidence(tiers)
+	consensus := computeConsensus(tiers)
+
+	return ConsolidatedResult{
+		Name:              group.Name,
+		ConsolidatedTier:  ScoreToTier(weightedScore),
+		ConsolidatedScore: math.Round(weightedScore*100) / 100,
+		Confidence:        confidence,
+		Consensus:         consensus,
+		MetaTFTTier:       tiers["metatft"],
+		TFTacticsTier:     tiers["tftactics"],
+		MobalyticsTier:    tiers["mobalytics"],
+		AvgWinRate:        avg(winRates),
+		AvgPlayRate:       avg(playRates),
+		AvgPlacement:      avg(placements),
+		CoreChampions:     group.ChampionIDs,
+		RecommendedItems:  group.CoreItems,
+	}
+}
+
+// computeConfidence determines confidence based on source agreement.
+func computeConfidence(tiers map[string]string) string {
+	if len(tiers) <= 1 {
+		return "low"
+	}
+
+	// Count how many sources agree within 1 tier
+	tierValues := make([]float64, 0, len(tiers))
+	for _, t := range tiers {
+		tierValues = append(tierValues, TierToScore[t])
+	}
+
+	// Check if all are within 20 points (1 tier difference)
+	allClose := true
+	for i := 0; i < len(tierValues); i++ {
+		for j := i + 1; j < len(tierValues); j++ {
+			if math.Abs(tierValues[i]-tierValues[j]) > 20 {
+				allClose = false
+			}
+		}
+	}
+
+	if allClose && len(tiers) >= 3 {
+		return "high"
+	}
+
+	// Check if majority (2/3) agree
+	tierCounts := make(map[string]int)
+	for _, t := range tiers {
+		tierCounts[t]++
+	}
+	for _, count := range tierCounts {
+		if count >= 2 {
+			return "medium"
+		}
+	}
+
+	return "low"
+}
+
+// computeConsensus determines the agreement level across sources.
+func computeConsensus(tiers map[string]string) string {
+	if len(tiers) <= 1 {
+		return "single_source"
+	}
+
+	tierCounts := make(map[string]int)
+	for _, t := range tiers {
+		tierCounts[t]++
+	}
+
+	if len(tierCounts) == 1 {
+		return "unanimous"
+	}
+
+	for _, count := range tierCounts {
+		if count >= 2 {
+			return "majority"
+		}
+	}
+
+	return "split"
+}
+
+func avg(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sum := 0.0
+	for _, v := range values {
+		sum += v
+	}
+	return math.Round(sum/float64(len(values))*100) / 100
+}

--- a/backend/internal/consolidation/types.go
+++ b/backend/internal/consolidation/types.go
@@ -1,0 +1,39 @@
+package consolidation
+
+// NormalizedComp represents a composition from one source after normalization.
+type NormalizedComp struct {
+	Source       string
+	Name         string
+	Tier         string
+	Score        float64
+	WinRate      float64
+	PlayRate     float64
+	AvgPlacement float64
+	ChampionIDs  []string
+	CoreItems    map[string][]string
+}
+
+// MatchGroup represents compositions from multiple sources that are the same comp.
+type MatchGroup struct {
+	Name         string            // canonical name (from first source found)
+	Sources      []NormalizedComp  // one per source (max 3)
+	ChampionIDs  []string          // union of all champion lists
+	CoreItems    map[string][]string
+}
+
+// ConsolidatedResult is the output of the scoring step for one composition.
+type ConsolidatedResult struct {
+	Name              string
+	ConsolidatedTier  string
+	ConsolidatedScore float64
+	Confidence        string
+	Consensus         string
+	MetaTFTTier       string
+	TFTacticsTier     string
+	MobalyticsTier    string
+	AvgWinRate        float64
+	AvgPlayRate       float64
+	AvgPlacement      float64
+	CoreChampions     []string
+	RecommendedItems  map[string][]string
+}

--- a/backend/internal/crawler/crawler.go
+++ b/backend/internal/crawler/crawler.go
@@ -1,0 +1,211 @@
+package crawler
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/sync/errgroup"
+)
+
+// Scraper defines the contract for a single-site scraper.
+type Scraper interface {
+	// Name returns the source identifier (e.g. "metatft").
+	Name() string
+	// Scrape fetches and parses tier list data from the source.
+	Scrape(ctx context.Context) (*ScrapeResult, error)
+}
+
+// OnCompleteFunc is called after a crawl cycle completes with the patch version.
+type OnCompleteFunc func(ctx context.Context, patch string) error
+
+// Crawler orchestrates multiple scrapers and stores results.
+type Crawler struct {
+	scrapers   []Scraper
+	store      *Store
+	interval   time.Duration
+	onComplete OnCompleteFunc
+
+	mu       sync.Mutex
+	statuses map[string]*SourceStatusInfo
+}
+
+// New creates a new Crawler.
+func New(db *pgxpool.Pool, scrapers []Scraper, interval time.Duration, onComplete OnCompleteFunc) *Crawler {
+	statuses := make(map[string]*SourceStatusInfo, len(scrapers))
+	for _, s := range scrapers {
+		statuses[s.Name()] = &SourceStatusInfo{
+			Source: s.Name(),
+			Status: "never",
+		}
+	}
+
+	return &Crawler{
+		scrapers:   scrapers,
+		store:      NewStore(db),
+		interval:   interval,
+		onComplete: onComplete,
+		statuses:   statuses,
+	}
+}
+
+// Run executes a single crawl cycle: scrapes all sources in parallel, stores results,
+// then triggers consolidation.
+func (c *Crawler) Run(ctx context.Context) error {
+	log.Println("crawler: starting crawl cycle...")
+	start := time.Now()
+
+	type result struct {
+		scrapeResult *ScrapeResult
+		err          error
+		name         string
+	}
+
+	results := make([]result, len(c.scrapers))
+	g, gCtx := errgroup.WithContext(ctx)
+
+	for i, scraper := range c.scrapers {
+		g.Go(func() error {
+			log.Printf("crawler: scraping %s...", scraper.Name())
+			sr, err := scraper.Scrape(gCtx)
+			results[i] = result{scrapeResult: sr, err: err, name: scraper.Name()}
+			// Don't propagate errors — one failure shouldn't block others
+			return nil
+		})
+	}
+
+	_ = g.Wait()
+
+	// Process results
+	var (
+		successCount int
+		lastPatch    string
+	)
+
+	for _, r := range results {
+		c.mu.Lock()
+		status := c.statuses[r.name]
+
+		if r.err != nil {
+			log.Printf("crawler: %s failed: %v", r.name, r.err)
+			status.Status = "error"
+			status.ErrorMessage = r.err.Error()
+			c.mu.Unlock()
+			continue
+		}
+
+		// Store the scraped data
+		if err := c.store.SaveResult(ctx, r.scrapeResult); err != nil {
+			log.Printf("crawler: failed to store %s results: %v", r.name, err)
+			status.Status = "error"
+			status.ErrorMessage = fmt.Sprintf("store failed: %v", err)
+			c.mu.Unlock()
+			continue
+		}
+
+		status.Status = "ok"
+		status.LastScraped = r.scrapeResult.ScrapedAt
+		status.ErrorMessage = ""
+		c.mu.Unlock()
+
+		successCount++
+		if r.scrapeResult.Patch != "" && r.scrapeResult.Patch != "unknown" {
+			lastPatch = r.scrapeResult.Patch
+		} else if lastPatch == "" {
+			lastPatch = r.scrapeResult.Patch
+		}
+	}
+
+	// Normalize patches — use the best known patch for all "unknown" results
+	if lastPatch != "" && lastPatch != "unknown" {
+		for _, r := range results {
+			if r.scrapeResult != nil && (r.scrapeResult.Patch == "" || r.scrapeResult.Patch == "unknown") {
+				r.scrapeResult.Patch = lastPatch
+				// Re-store with correct patch
+				_ = c.store.SaveResult(ctx, r.scrapeResult)
+			}
+		}
+	}
+
+	log.Printf("crawler: cycle complete — %d/%d sources succeeded (%v)",
+		successCount, len(c.scrapers), time.Since(start))
+
+	// Trigger consolidation if we have any data
+	if successCount > 0 && lastPatch != "" && c.onComplete != nil {
+		log.Printf("crawler: triggering consolidation for patch %s...", lastPatch)
+		if err := c.onComplete(ctx, lastPatch); err != nil {
+			log.Printf("crawler: consolidation failed: %v", err)
+			return fmt.Errorf("consolidation: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// StartScheduler runs the crawler on a periodic schedule.
+// It blocks until the context is cancelled.
+func (c *Crawler) StartScheduler(ctx context.Context) {
+	log.Printf("crawler: scheduler started (interval: %v)", c.interval)
+
+	// Run immediately on first start if data is stale
+	if c.shouldRunNow(ctx) {
+		if err := c.Run(ctx); err != nil {
+			log.Printf("crawler: initial run failed: %v", err)
+		}
+	}
+
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("crawler: scheduler stopped")
+			return
+		case <-ticker.C:
+			if err := c.Run(ctx); err != nil {
+				log.Printf("crawler: scheduled run failed: %v", err)
+			}
+		}
+	}
+}
+
+// shouldRunNow checks if the last scrape is older than the interval.
+func (c *Crawler) shouldRunNow(ctx context.Context) bool {
+	latest, err := c.store.queries.GetLatestScrapedAt(ctx)
+	if err != nil || latest == nil {
+		return true // No data yet
+	}
+
+	if t, ok := latest.(time.Time); ok {
+		return time.Since(t) > c.interval
+	}
+	return true
+}
+
+// GetStatuses returns the current scraper statuses.
+func (c *Crawler) GetStatuses() []SourceStatusInfo {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	out := make([]SourceStatusInfo, 0, len(c.statuses))
+	for _, s := range c.statuses {
+		out = append(out, *s)
+	}
+	return out
+}
+
+// --- Shared helpers ---
+
+// normalizeTier converts tier strings to a consistent uppercase format.
+func normalizeTier(tier string) string {
+	t := strings.ToUpper(strings.TrimSpace(tier))
+	if t == "S+" {
+		return "S"
+	}
+	return t
+}

--- a/backend/internal/crawler/httpclient.go
+++ b/backend/internal/crawler/httpclient.go
@@ -1,0 +1,161 @@
+package crawler
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+const (
+	maxRetries     = 3
+	baseRetryDelay = 1 * time.Second
+	maxRetryDelay  = 10 * time.Second
+	defaultTimeout = 30 * time.Second
+	userAgent      = "TFTOracle/1.0 (https://github.com/MeninoNias/tft-oracle)"
+)
+
+// HTTPClient is a shared HTTP client with retry and rate limiting for web scraping.
+type HTTPClient struct {
+	http    *http.Client
+	limiter *rate.Limiter
+	baseURL string // override for tests
+}
+
+// NewHTTPClient creates a scraping HTTP client.
+func NewHTTPClient() *HTTPClient {
+	return &HTTPClient{
+		http: &http.Client{
+			Timeout: defaultTimeout,
+		},
+		// Conservative: 1 request per second per scraper
+		limiter: rate.NewLimiter(rate.Every(time.Second), 1),
+	}
+}
+
+// Get fetches a URL with rate limiting, retry logic, and proper headers.
+func (c *HTTPClient) Get(ctx context.Context, rawURL string) ([]byte, error) {
+	if c.baseURL != "" {
+		rawURL = c.baseURL + rawURL
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if err := c.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("rate limiter: %w", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("User-Agent", userAgent)
+		req.Header.Set("Accept", "text/html,application/json")
+
+		resp, err := c.http.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("http request: %w", err)
+			if attempt < maxRetries {
+				sleepWithContext(ctx, retryDelay(attempt))
+				continue
+			}
+			return nil, lastErr
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read response body: %w", err)
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			return body, nil
+		}
+
+		lastErr = fmt.Errorf("http %d: %s", resp.StatusCode, truncate(string(body), 200))
+
+		// Retry on server errors and rate limits
+		if (resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests) && attempt < maxRetries {
+			sleepWithContext(ctx, retryDelay(attempt))
+			continue
+		}
+
+		return nil, lastErr
+	}
+	return nil, lastErr
+}
+
+func retryDelay(attempt int) time.Duration {
+	d := baseRetryDelay * (1 << uint(attempt))
+	if d > maxRetryDelay {
+		return maxRetryDelay
+	}
+	return d
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) {
+	select {
+	case <-time.After(d):
+	case <-ctx.Done():
+	}
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
+// Post sends a POST request with JSON body (needed for GraphQL endpoints).
+func (c *HTTPClient) Post(ctx context.Context, rawURL string, body []byte) ([]byte, error) {
+	if c.baseURL != "" {
+		rawURL = c.baseURL + rawURL
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if err := c.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("rate limiter: %w", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", userAgent)
+
+		resp, err := c.http.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("http request: %w", err)
+			if attempt < maxRetries {
+				sleepWithContext(ctx, retryDelay(attempt))
+				continue
+			}
+			return nil, lastErr
+		}
+
+		respBody, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read response body: %w", err)
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			return respBody, nil
+		}
+
+		lastErr = fmt.Errorf("http %d: %s", resp.StatusCode, truncate(string(respBody), 200))
+		if (resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests) && attempt < maxRetries {
+			sleepWithContext(ctx, retryDelay(attempt))
+			continue
+		}
+		return nil, lastErr
+	}
+	return nil, lastErr
+}

--- a/backend/internal/crawler/metatft.go
+++ b/backend/internal/crawler/metatft.go
@@ -1,0 +1,26 @@
+package crawler
+
+import (
+	"context"
+	"fmt"
+)
+
+const metatftSource = "metatft"
+
+// MetaTFTScraper is a placeholder for MetaTFT scraping.
+// MetaTFT is a client-side SPA with no public API — scraping requires
+// a headless browser (Puppeteer/Chromedp), which is planned for a future iteration.
+type MetaTFTScraper struct {
+	client *HTTPClient
+}
+
+// NewMetaTFTScraper creates a MetaTFT scraper.
+func NewMetaTFTScraper(client *HTTPClient) *MetaTFTScraper {
+	return &MetaTFTScraper{client: client}
+}
+
+func (s *MetaTFTScraper) Name() string { return metatftSource }
+
+func (s *MetaTFTScraper) Scrape(ctx context.Context) (*ScrapeResult, error) {
+	return nil, fmt.Errorf("metatft scraper not yet implemented — requires headless browser")
+}

--- a/backend/internal/crawler/mobalytics.go
+++ b/backend/internal/crawler/mobalytics.go
@@ -1,0 +1,187 @@
+package crawler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	mobalyticsSource     = "mobalytics"
+	mobalyticsGraphQLURL = "https://mobalytics.gg/api/tft/v1/graphql/query"
+)
+
+// MobalyticsScraper scrapes composition tier data from Mobalytics via GraphQL.
+type MobalyticsScraper struct {
+	client *HTTPClient
+}
+
+// NewMobalyticsScraper creates a Mobalytics scraper.
+func NewMobalyticsScraper(client *HTTPClient) *MobalyticsScraper {
+	return &MobalyticsScraper{client: client}
+}
+
+func (s *MobalyticsScraper) Name() string { return mobalyticsSource }
+
+func (s *MobalyticsScraper) Scrape(ctx context.Context) (*ScrapeResult, error) {
+	var allComps []RawComposition
+	var patch string
+
+	for _, tier := range []string{"s", "a", "b", "c"} {
+		comps, p, err := s.scrapeTier(ctx, tier)
+		if err != nil {
+			return nil, fmt.Errorf("scrape tier %s: %w", tier, err)
+		}
+		allComps = append(allComps, comps...)
+		if p != "" {
+			patch = p
+		}
+	}
+
+	if len(allComps) == 0 {
+		return nil, fmt.Errorf("mobalytics returned 0 compositions")
+	}
+
+	return &ScrapeResult{
+		Source:       mobalyticsSource,
+		Patch:        patch,
+		Compositions: allComps,
+		ScrapedAt:    time.Now(),
+	}, nil
+}
+
+func (s *MobalyticsScraper) scrapeTier(ctx context.Context, tier string) ([]RawComposition, string, error) {
+	query := `{
+		tft {
+			metaCompositions(filter: {set: "16", tier: "` + tier + `"}, first: 50) {
+				items {
+					name
+					tier
+					patch
+					slug
+					formation {
+						positions {
+							champion {
+								champion { slug }
+								items { slug }
+								level
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	body, err := json.Marshal(map[string]string{"query": query})
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal query: %w", err)
+	}
+
+	respBody, err := s.client.Post(ctx, mobalyticsGraphQLURL, body)
+	if err != nil {
+		return nil, "", fmt.Errorf("graphql request: %w", err)
+	}
+
+	var resp mobalyticsGQLResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, "", fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	items := resp.Data.TFT.MetaCompositions.Items
+	if len(items) == 0 {
+		return nil, "", nil
+	}
+
+	patch := items[0].Patch
+	comps := make([]RawComposition, 0, len(items))
+
+	for _, item := range items {
+		champIDs := make([]string, 0)
+		coreItems := make(map[string][]string)
+
+		for _, pos := range item.Formation.Positions {
+			slug := pos.Champion.Champion.Slug
+			apiName := slugToApiName(slug)
+			champIDs = append(champIDs, apiName)
+
+			if len(pos.Champion.Items) > 0 {
+				itemSlugs := make([]string, 0, len(pos.Champion.Items))
+				for _, it := range pos.Champion.Items {
+					itemSlugs = append(itemSlugs, it.Slug)
+				}
+				coreItems[apiName] = itemSlugs
+			}
+		}
+
+		comps = append(comps, RawComposition{
+			Name:        item.Name,
+			Tier:        normalizeTier(item.Tier),
+			ChampionIDs: champIDs,
+			CoreItems:   coreItems,
+		})
+	}
+
+	return comps, patch, nil
+}
+
+// slugToApiName converts Mobalytics slug to Riot api_name format.
+func slugToApiName(slug string) string {
+	known := map[string]string{
+		"kogmaw":      "TFT16_KogMaw",
+		"missfortune": "TFT16_MissFortune",
+		"luciansenna": "TFT16_LucianSenna",
+		"kobukoyuumi": "TFT16_KobukoYuumi",
+		"baronnashor": "TFT16_BaronNashor",
+		"riftherald":  "TFT16_RiftHerald",
+		"drmundo":     "TFT16_DrMundo",
+		"reksai":      "TFT16_RekSai",
+		"tahmkench":   "TFT16_TahmKench",
+		"chogath":     "TFT16_ChoGath",
+	}
+
+	if name, ok := known[slug]; ok {
+		return name
+	}
+
+	if len(slug) == 0 {
+		return slug
+	}
+	return "TFT16_" + strings.ToUpper(slug[:1]) + slug[1:]
+}
+
+// --- GraphQL response types ---
+
+type mobalyticsGQLResponse struct {
+	Data struct {
+		TFT struct {
+			MetaCompositions struct {
+				Items []mobalyticsCompItem `json:"items"`
+			} `json:"metaCompositions"`
+		} `json:"tft"`
+	} `json:"data"`
+}
+
+type mobalyticsCompItem struct {
+	Name      string `json:"name"`
+	Tier      string `json:"tier"`
+	Patch     string `json:"patch"`
+	Slug      string `json:"slug"`
+	Formation struct {
+		Positions []mobalyticsPosition `json:"positions"`
+	} `json:"formation"`
+}
+
+type mobalyticsPosition struct {
+	Champion struct {
+		Champion struct {
+			Slug string `json:"slug"`
+		} `json:"champion"`
+		Items []struct {
+			Slug string `json:"slug"`
+		} `json:"items"`
+		Level int `json:"level"`
+	} `json:"champion"`
+}

--- a/backend/internal/crawler/store.go
+++ b/backend/internal/crawler/store.go
@@ -1,0 +1,105 @@
+package crawler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/big"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/MeninoNias/tft-oracle/backend/sqlc/generated"
+)
+
+// Store handles persisting raw tier data to the database.
+type Store struct {
+	db      *pgxpool.Pool
+	queries *generated.Queries
+}
+
+// NewStore creates a new crawler store.
+func NewStore(db *pgxpool.Pool) *Store {
+	return &Store{
+		db:      db,
+		queries: generated.New(db),
+	}
+}
+
+// SaveResult persists a scrape result to the database.
+// It deletes old data for the source+patch and inserts new rows in a single transaction.
+func (s *Store) SaveResult(ctx context.Context, result *ScrapeResult) error {
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	qtx := s.queries.WithTx(tx)
+
+	// Delete old data for this source+patch
+	if err := qtx.DeleteRawTierDataBySourceAndPatch(ctx, generated.DeleteRawTierDataBySourceAndPatchParams{
+		Source: result.Source,
+		Patch:  result.Patch,
+	}); err != nil {
+		return fmt.Errorf("delete old data: %w", err)
+	}
+
+	// Insert new compositions
+	for _, comp := range result.Compositions {
+		coreItemsJSON, err := json.Marshal(comp.CoreItems)
+		if err != nil {
+			return fmt.Errorf("marshal core items: %w", err)
+		}
+
+		championIDs := comp.ChampionIDs
+		if championIDs == nil {
+			championIDs = []string{}
+		}
+
+		_, err = qtx.InsertRawTierData(ctx, generated.InsertRawTierDataParams{
+			Source:          result.Source,
+			Patch:           result.Patch,
+			CompositionName: comp.Name,
+			Tier:            textFromString(comp.Tier),
+			WinRate:         numericFromFloat(comp.WinRate),
+			PlayRate:        numericFromFloat(comp.PlayRate),
+			AvgPlacement:    numericFromFloat(comp.AvgPlacement),
+			ChampionIds:     championIDs,
+			CoreItems:       coreItemsJSON,
+		})
+		if err != nil {
+			return fmt.Errorf("insert comp %q: %w", comp.Name, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
+	}
+
+	log.Printf("crawler: stored %d compositions from %s (patch %s)",
+		len(result.Compositions), result.Source, result.Patch)
+	return nil
+}
+
+func textFromString(s string) pgtype.Text {
+	if s == "" {
+		return pgtype.Text{Valid: false}
+	}
+	return pgtype.Text{String: s, Valid: true}
+}
+
+func numericFromFloat(f float64) pgtype.Numeric {
+	if f == 0 {
+		return pgtype.Numeric{Valid: false}
+	}
+	// Convert float to *big.Int with 2 decimal places
+	scaled := int64(f * 100)
+	return pgtype.Numeric{
+		Int:   big.NewInt(scaled),
+		Exp:   -2,
+		Valid: true,
+	}
+}

--- a/backend/internal/crawler/tftactics.go
+++ b/backend/internal/crawler/tftactics.go
@@ -1,0 +1,197 @@
+package crawler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"time"
+)
+
+const (
+	tacticsToolsSource = "tacticstools"
+	tacticsToolsURL    = "https://tactics.tools/team-compositions"
+)
+
+// TacticsToolsScraper scrapes composition data from tactics.tools via __NEXT_DATA__.
+type TacticsToolsScraper struct {
+	client *HTTPClient
+}
+
+// NewTacticsToolsScraper creates a tactics.tools scraper.
+func NewTacticsToolsScraper(client *HTTPClient) *TacticsToolsScraper {
+	return &TacticsToolsScraper{client: client}
+}
+
+func (s *TacticsToolsScraper) Name() string { return tacticsToolsSource }
+
+func (s *TacticsToolsScraper) Scrape(ctx context.Context) (*ScrapeResult, error) {
+	body, err := s.client.Get(ctx, tacticsToolsURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetch tactics.tools: %w", err)
+	}
+
+	comps, patch, err := parseTacticsToolsHTML(body)
+	if err != nil {
+		return nil, fmt.Errorf("parse tactics.tools: %w", err)
+	}
+
+	if len(comps) == 0 {
+		return nil, fmt.Errorf("tactics.tools returned 0 compositions")
+	}
+
+	return &ScrapeResult{
+		Source:       tacticsToolsSource,
+		Patch:        patch,
+		Compositions: comps,
+		ScrapedAt:    time.Now(),
+	}, nil
+}
+
+var nextDataRe = regexp.MustCompile(`<script id="__NEXT_DATA__" type="application/json">(.*?)</script>`)
+
+func parseTacticsToolsHTML(html []byte) ([]RawComposition, string, error) {
+	matches := nextDataRe.FindSubmatch(html)
+	if len(matches) < 2 {
+		return nil, "", fmt.Errorf("__NEXT_DATA__ not found in HTML")
+	}
+
+	var nextData tacticsToolsNextData
+	if err := json.Unmarshal(matches[1], &nextData); err != nil {
+		return nil, "", fmt.Errorf("unmarshal __NEXT_DATA__: %w", err)
+	}
+
+	data := nextData.Props.PageProps.InitialData
+	if data == nil {
+		return nil, "", fmt.Errorf("no initialData in page props")
+	}
+
+	// Determine patch from aperture
+	patch := "unknown"
+
+	// Process compositions from nonSpatComps (main comp list)
+	rawComps := data.NonSpatComps
+	if len(rawComps) == 0 && len(data.Groups) > 0 {
+		// Fall back to groups
+		for _, g := range data.Groups {
+			rawComps = append(rawComps, g.Full.Comps...)
+		}
+	}
+
+	comps := make([]RawComposition, 0, len(rawComps))
+	for _, rc := range rawComps {
+		if len(rc.Units) == 0 {
+			continue
+		}
+
+		// Validate data
+		if rc.Place < 1 || rc.Place > 8 {
+			continue
+		}
+
+		// Calculate win rate and play rate
+		winRate := 0.0
+		if rc.Count > 0 {
+			winRate = float64(rc.Win) / float64(rc.Count) * 100
+		}
+
+		top4Rate := 0.0
+		if rc.Count > 0 {
+			top4Rate = float64(rc.Top4) / float64(rc.Count) * 100
+		}
+
+		// Assign tier based on average placement
+		tier := placementToTier(rc.Place)
+
+		// Name from champion list (no names in data)
+		name := buildCompName(rc.Units)
+
+		comps = append(comps, RawComposition{
+			Name:         name,
+			Tier:         tier,
+			WinRate:      winRate,
+			PlayRate:     top4Rate, // Using top4 rate as "play rate" metric
+			AvgPlacement: rc.Place,
+			ChampionIDs:  rc.Units,
+			CoreItems:    make(map[string][]string),
+		})
+	}
+
+	return comps, patch, nil
+}
+
+// placementToTier maps average placement to a tier letter.
+func placementToTier(avgPlace float64) string {
+	switch {
+	case avgPlace <= 3.2:
+		return "S"
+	case avgPlace <= 3.8:
+		return "A"
+	case avgPlace <= 4.3:
+		return "B"
+	default:
+		return "C"
+	}
+}
+
+// buildCompName creates a human-readable name from champion IDs.
+func buildCompName(units []string) string {
+	if len(units) == 0 {
+		return "Unknown"
+	}
+	// Take first 2-3 champs, strip the TFT16_ prefix
+	names := make([]string, 0, 3)
+	for i, u := range units {
+		if i >= 3 {
+			break
+		}
+		name := u
+		if idx := len("TFT16_"); len(u) > idx && u[:idx] == "TFT16_" {
+			name = u[idx:]
+		}
+		names = append(names, name)
+	}
+	result := ""
+	for i, n := range names {
+		if i > 0 {
+			result += " "
+		}
+		result += n
+	}
+	return result
+}
+
+// --- __NEXT_DATA__ response types ---
+
+type tacticsToolsNextData struct {
+	Props struct {
+		PageProps struct {
+			InitialData *tacticsToolsData `json:"initialData"`
+		} `json:"pageProps"`
+	} `json:"props"`
+}
+
+type tacticsToolsData struct {
+	Count        int                    `json:"count"`
+	Place        float64                `json:"place"`
+	Top4         int                    `json:"top4"`
+	Win          int                    `json:"win"`
+	NonSpatComps []tacticsToolsComp     `json:"nonSpatComps"`
+	Groups       []tacticsToolsGroup    `json:"groups"`
+}
+
+type tacticsToolsGroup struct {
+	Full struct {
+		Comps []tacticsToolsComp `json:"comps"`
+	} `json:"full"`
+}
+
+type tacticsToolsComp struct {
+	Units       []string `json:"units"`
+	SpatItems   []string `json:"spatItems"`
+	ExtraTraits []string `json:"extraTraits"`
+	Count       int      `json:"count"`
+	Place       float64  `json:"place"`
+	Top4        int      `json:"top4"`
+	Win         int      `json:"win"`
+}

--- a/backend/internal/crawler/types.go
+++ b/backend/internal/crawler/types.go
@@ -1,0 +1,30 @@
+package crawler
+
+import "time"
+
+// RawComposition represents a single composition scraped from a tier list site.
+type RawComposition struct {
+	Name         string            `json:"name"`
+	Tier         string            `json:"tier"`
+	WinRate      float64           `json:"win_rate"`
+	PlayRate     float64           `json:"play_rate"`
+	AvgPlacement float64           `json:"avg_placement"`
+	ChampionIDs  []string          `json:"champion_ids"`  // api_names
+	CoreItems    map[string][]string `json:"core_items"`   // champion_api_name -> [item_api_names]
+}
+
+// ScrapeResult holds the output of a single scrape operation.
+type ScrapeResult struct {
+	Source       string           `json:"source"`
+	Patch        string           `json:"patch"`
+	Compositions []RawComposition `json:"compositions"`
+	ScrapedAt    time.Time        `json:"scraped_at"`
+}
+
+// SourceStatusInfo tracks the health of each scraper.
+type SourceStatusInfo struct {
+	Source       string
+	LastScraped  time.Time
+	Status       string // "ok", "error", "never"
+	ErrorMessage string
+}

--- a/backend/internal/simulation/service.go
+++ b/backend/internal/simulation/service.go
@@ -10,6 +10,7 @@ import (
 	tftv1 "github.com/MeninoNias/tft-oracle/backend/gen/tft/v1"
 	"github.com/MeninoNias/tft-oracle/backend/gen/tft/v1/tftv1connect"
 	"github.com/MeninoNias/tft-oracle/backend/internal/ai"
+	"github.com/MeninoNias/tft-oracle/backend/internal/auth"
 	"github.com/MeninoNias/tft-oracle/backend/sqlc/generated"
 )
 
@@ -33,6 +34,11 @@ func (s *Service) SimulateBattle(
 	ctx context.Context,
 	req *connect.Request[tftv1.SimulateBattleRequest],
 ) (*connect.Response[tftv1.SimulateBattleResponse], error) {
+	// Require authentication
+	if _, err := auth.RequireAuth(ctx); err != nil {
+		return nil, err
+	}
+
 	// Validate request
 	if req.Msg.PlayerBoard == nil || len(req.Msg.PlayerBoard.Champions) == 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument,

--- a/backend/internal/tierlist/mapper.go
+++ b/backend/internal/tierlist/mapper.go
@@ -1,0 +1,57 @@
+package tierlist
+
+import (
+	"encoding/json"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	tftv1 "github.com/MeninoNias/tft-oracle/backend/gen/tft/v1"
+	"github.com/MeninoNias/tft-oracle/backend/sqlc/generated"
+)
+
+func mapToProto(row generated.ConsolidatedTierList) *tftv1.TierListEntry {
+	entry := &tftv1.TierListEntry{
+		CompositionName:   row.CompositionName,
+		ConsolidatedTier:  row.ConsolidatedTier,
+		ConsolidatedScore: numericToFloat64(row.ConsolidatedScore),
+		Confidence:        row.Confidence,
+		Consensus:         row.Consensus,
+		MetatftTier:       textToString(row.MetatftTier),
+		TftacticsTier:     textToString(row.TftacticsTier),
+		MobalyticsTier:    textToString(row.MobalyticsTier),
+		AvgWinRate:        numericToFloat64(row.AvgWinRate),
+		AvgPlayRate:       numericToFloat64(row.AvgPlayRate),
+		AvgPlacement:      numericToFloat64(row.AvgPlacement),
+		CoreChampions:     row.CoreChampions,
+	}
+
+	// Parse recommended items from JSONB
+	if len(row.RecommendedItems) > 0 {
+		var items map[string][]string
+		if err := json.Unmarshal(row.RecommendedItems, &items); err == nil {
+			entry.RecommendedItems = make(map[string]*tftv1.ItemList, len(items))
+			for champ, itemList := range items {
+				entry.RecommendedItems[champ] = &tftv1.ItemList{
+					ItemApiNames: itemList,
+				}
+			}
+		}
+	}
+
+	return entry
+}
+
+func textToString(t pgtype.Text) string {
+	if !t.Valid {
+		return ""
+	}
+	return t.String
+}
+
+func numericToFloat64(n pgtype.Numeric) float64 {
+	if !n.Valid || n.Int == nil {
+		return 0
+	}
+	f, _ := n.Float64Value()
+	return f.Float64
+}

--- a/backend/internal/tierlist/service.go
+++ b/backend/internal/tierlist/service.go
@@ -1,0 +1,128 @@
+package tierlist
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"connectrpc.com/connect"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	tftv1 "github.com/MeninoNias/tft-oracle/backend/gen/tft/v1"
+	"github.com/MeninoNias/tft-oracle/backend/gen/tft/v1/tftv1connect"
+	"github.com/MeninoNias/tft-oracle/backend/internal/crawler"
+	"github.com/MeninoNias/tft-oracle/backend/sqlc/generated"
+)
+
+var _ tftv1connect.TierListServiceHandler = (*Service)(nil)
+
+// Service handles tier list RPCs.
+type Service struct {
+	db      *pgxpool.Pool
+	queries *generated.Queries
+	crawler *crawler.Crawler
+}
+
+// NewService creates a new TierList service.
+func NewService(db *pgxpool.Pool, c *crawler.Crawler) *Service {
+	return &Service{
+		db:      db,
+		queries: generated.New(db),
+		crawler: c,
+	}
+}
+
+func (s *Service) GetConsolidatedTierList(
+	ctx context.Context,
+	req *connect.Request[tftv1.GetConsolidatedTierListRequest],
+) (*connect.Response[tftv1.GetConsolidatedTierListResponse], error) {
+	patch := req.Msg.Patch
+	tierFilter := req.Msg.TierFilter
+
+	// If no patch specified, use latest available
+	if patch == "" {
+		latestPatch, err := s.queries.GetLatestConsolidatedPatch(ctx)
+		if err == nil {
+			patch = latestPatch
+		}
+	}
+
+	var rows []generated.ConsolidatedTierList
+	var err error
+
+	if tierFilter != "" {
+		rows, err = s.queries.GetConsolidatedTierListByTier(ctx, generated.GetConsolidatedTierListByTierParams{
+			Patch:            patch,
+			ConsolidatedTier: tierFilter,
+		})
+	} else {
+		rows, err = s.queries.GetConsolidatedTierList(ctx, patch)
+	}
+
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("query tier list: %w", err))
+	}
+
+	entries := make([]*tftv1.TierListEntry, 0, len(rows))
+	for _, row := range rows {
+		entries = append(entries, mapToProto(row))
+	}
+
+	// Determine last_updated from the most recent entry
+	lastUpdated := ""
+	if len(rows) > 0 && rows[0].UpdatedAt.Valid {
+		lastUpdated = rows[0].UpdatedAt.Time.Format("2006-01-02T15:04:05Z")
+	}
+
+	return connect.NewResponse(&tftv1.GetConsolidatedTierListResponse{
+		Patch:       patch,
+		Entries:     entries,
+		LastUpdated: lastUpdated,
+	}), nil
+}
+
+func (s *Service) TriggerCrawl(
+	ctx context.Context,
+	req *connect.Request[tftv1.TriggerCrawlRequest],
+) (*connect.Response[tftv1.TriggerCrawlResponse], error) {
+	if s.crawler == nil {
+		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("crawler not configured"))
+	}
+
+	// Run crawl in a goroutine to not block the RPC
+	go func() {
+		bgCtx := context.Background()
+		if err := s.crawler.Run(bgCtx); err != nil {
+			log.Printf("tierlist: triggered crawl failed: %v", err)
+		}
+	}()
+
+	return connect.NewResponse(&tftv1.TriggerCrawlResponse{
+		Message: "crawl triggered",
+	}), nil
+}
+
+func (s *Service) GetCrawlerStatus(
+	ctx context.Context,
+	req *connect.Request[tftv1.GetCrawlerStatusRequest],
+) (*connect.Response[tftv1.GetCrawlerStatusResponse], error) {
+	resp := &tftv1.GetCrawlerStatusResponse{}
+
+	if s.crawler != nil {
+		statuses := s.crawler.GetStatuses()
+		for _, st := range statuses {
+			lastScraped := ""
+			if !st.LastScraped.IsZero() {
+				lastScraped = st.LastScraped.Format("2006-01-02T15:04:05Z")
+			}
+			resp.Sources = append(resp.Sources, &tftv1.SourceStatus{
+				Source:       st.Source,
+				LastScraped:  lastScraped,
+				Status:       st.Status,
+				ErrorMessage: st.ErrorMessage,
+			})
+		}
+	}
+
+	return connect.NewResponse(resp), nil
+}

--- a/backend/sqlc/queries/coach_analyses.sql
+++ b/backend/sqlc/queries/coach_analyses.sql
@@ -1,0 +1,29 @@
+-- name: GetCoachMatchAnalysis :one
+SELECT * FROM coach_match_analyses
+WHERE match_id = $1 AND puuid = $2;
+
+-- name: UpsertCoachMatchAnalysis :one
+INSERT INTO coach_match_analyses (match_id, puuid, response, model, tokens_used)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (match_id, puuid) DO UPDATE SET
+    response = EXCLUDED.response,
+    model = EXCLUDED.model,
+    tokens_used = EXCLUDED.tokens_used,
+    created_at = NOW()
+RETURNING *;
+
+-- name: GetCoachHistoryAnalysis :one
+SELECT * FROM coach_history_analyses
+WHERE puuid = $1 AND match_count = $2
+  AND created_at > NOW() - INTERVAL '1 hour';
+
+-- name: UpsertCoachHistoryAnalysis :one
+INSERT INTO coach_history_analyses (puuid, match_count, match_ids, response, model, tokens_used)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (puuid, match_count) DO UPDATE SET
+    match_ids = EXCLUDED.match_ids,
+    response = EXCLUDED.response,
+    model = EXCLUDED.model,
+    tokens_used = EXCLUDED.tokens_used,
+    created_at = NOW()
+RETURNING *;

--- a/backend/sqlc/queries/consolidated_tier_list.sql
+++ b/backend/sqlc/queries/consolidated_tier_list.sql
@@ -1,0 +1,44 @@
+-- name: UpsertConsolidatedTierEntry :one
+INSERT INTO consolidated_tier_list (
+    patch, composition_name, consolidated_tier, consolidated_score,
+    confidence, consensus,
+    metatft_tier, tftactics_tier, mobalytics_tier,
+    avg_win_rate, avg_play_rate, avg_placement,
+    core_champions, recommended_items, updated_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NOW()
+)
+ON CONFLICT (patch, composition_name) DO UPDATE SET
+    consolidated_tier  = EXCLUDED.consolidated_tier,
+    consolidated_score = EXCLUDED.consolidated_score,
+    confidence         = EXCLUDED.confidence,
+    consensus          = EXCLUDED.consensus,
+    metatft_tier       = EXCLUDED.metatft_tier,
+    tftactics_tier     = EXCLUDED.tftactics_tier,
+    mobalytics_tier    = EXCLUDED.mobalytics_tier,
+    avg_win_rate       = EXCLUDED.avg_win_rate,
+    avg_play_rate      = EXCLUDED.avg_play_rate,
+    avg_placement      = EXCLUDED.avg_placement,
+    core_champions     = EXCLUDED.core_champions,
+    recommended_items  = EXCLUDED.recommended_items,
+    updated_at         = NOW()
+RETURNING *;
+
+-- name: GetConsolidatedTierList :many
+SELECT * FROM consolidated_tier_list
+WHERE patch = $1
+ORDER BY consolidated_score DESC;
+
+-- name: GetConsolidatedTierListByTier :many
+SELECT * FROM consolidated_tier_list
+WHERE patch = $1 AND consolidated_tier = $2
+ORDER BY consolidated_score DESC;
+
+-- name: DeleteConsolidatedByPatch :exec
+DELETE FROM consolidated_tier_list
+WHERE patch = $1;
+
+-- name: GetLatestConsolidatedPatch :one
+SELECT patch FROM consolidated_tier_list
+ORDER BY updated_at DESC
+LIMIT 1;

--- a/backend/sqlc/queries/raw_tier_data.sql
+++ b/backend/sqlc/queries/raw_tier_data.sql
@@ -1,0 +1,26 @@
+-- name: InsertRawTierData :one
+INSERT INTO raw_tier_data (
+    source, patch, composition_name, tier,
+    win_rate, play_rate, avg_placement,
+    champion_ids, core_items, scraped_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, NOW()
+)
+RETURNING *;
+
+-- name: GetRawTierDataByPatch :many
+SELECT * FROM raw_tier_data
+WHERE patch = $1
+ORDER BY source, tier, composition_name;
+
+-- name: GetRawTierDataBySourceAndPatch :many
+SELECT * FROM raw_tier_data
+WHERE source = $1 AND patch = $2
+ORDER BY tier, composition_name;
+
+-- name: DeleteRawTierDataBySourceAndPatch :exec
+DELETE FROM raw_tier_data
+WHERE source = $1 AND patch = $2;
+
+-- name: GetLatestScrapedAt :one
+SELECT MAX(scraped_at) FROM raw_tier_data;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { UnauthorizedPage } from "@/pages/unauthorized";
 import { AugmentsPage } from "@/pages/augments";
 import { SettingsPage } from "@/pages/settings";
 import { SimulatorPage } from "@/pages/simulator";
+import { TierListPage } from "@/pages/tier-list";
 import { SplashScreen } from "@/components/splash-screen";
 import { useTheme } from "@/hooks/use-theme";
 
@@ -48,6 +49,7 @@ export function App() {
               <Route path="/items" element={<ItemsPage />} />
               <Route path="/augments" element={<AugmentsPage />} />
               <Route path="/simulator" element={<SimulatorPage />} />
+              <Route path="/tier-list" element={<TierListPage />} />
               <Route path="/profile" element={<ProfilePage />} />
               <Route path="/player" element={<PlayerPage />} />
               <Route path="/settings" element={<SettingsPage />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { UnauthorizedPage } from "@/pages/unauthorized";
 import { AugmentsPage } from "@/pages/augments";
 import { SettingsPage } from "@/pages/settings";
 import { SimulatorPage } from "@/pages/simulator";
+import { CoachPage } from "@/pages/coach";
 import { TierListPage } from "@/pages/tier-list";
 import { SplashScreen } from "@/components/splash-screen";
 import { useTheme } from "@/hooks/use-theme";
@@ -49,6 +50,7 @@ export function App() {
               <Route path="/items" element={<ItemsPage />} />
               <Route path="/augments" element={<AugmentsPage />} />
               <Route path="/simulator" element={<SimulatorPage />} />
+              <Route path="/coach" element={<CoachPage />} />
               <Route path="/tier-list" element={<TierListPage />} />
               <Route path="/profile" element={<ProfilePage />} />
               <Route path="/player" element={<PlayerPage />} />

--- a/frontend/src/components/auth/auth-gate.tsx
+++ b/frontend/src/components/auth/auth-gate.tsx
@@ -1,0 +1,26 @@
+import { type ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuthStore } from "@/stores/auth-store";
+import { GenericEmptyState } from "@/components/ui/generic-empty-state";
+
+interface AuthGateProps {
+  children: ReactNode;
+}
+
+export function AuthGate({ children }: AuthGateProps) {
+  const token = useAuthStore((s) => s.token);
+  const navigate = useNavigate();
+
+  if (!token) {
+    return (
+      <GenericEmptyState
+        title="authentication required"
+        description="you need to be logged in to access this feature. sign in with your riot id to continue."
+        actionLabel="login / register"
+        onAction={() => navigate("/auth")}
+      />
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/coach/history-analysis-panel.tsx
+++ b/frontend/src/components/coach/history-analysis-panel.tsx
@@ -1,0 +1,139 @@
+import { TerminalCard } from "@/components/ui/terminal-card";
+import { SkillRadarChart } from "@/components/coach/skill-radar-chart";
+import type { AnalyzeHistoryResponse } from "@/gen/tft/v1/coach_pb";
+
+interface HistoryAnalysisPanelProps {
+  analysis: AnalyzeHistoryResponse;
+}
+
+const sentimentColors: Record<string, string> = {
+  positive: "bg-green-500",
+  neutral: "bg-yellow-500",
+  negative: "bg-red-500",
+};
+
+const directionIcons: Record<string, string> = {
+  improving: "↑",
+  stable: "→",
+  declining: "↓",
+};
+
+const directionColors: Record<string, string> = {
+  improving: "text-green-400",
+  stable: "text-yellow-400",
+  declining: "text-red-400",
+};
+
+export function HistoryAnalysisPanel({
+  analysis,
+}: HistoryAnalysisPanelProps) {
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-medium uppercase text-lofi-accent">
+          ai coach
+        </span>
+        <span className="text-xs text-lofi-muted">
+          {analysis.matchesAnalyzed} matches analyzed
+        </span>
+      </div>
+
+      {/* Summary */}
+      <TerminalCard>
+        <p className="text-sm text-lofi-secondary">
+          {analysis.overallSummary}
+        </p>
+      </TerminalCard>
+
+      {/* Skill Radar */}
+      {analysis.skillRadar && (
+        <TerminalCard className="flex flex-col items-center">
+          <p className="mb-2 text-xs font-medium uppercase text-lofi-muted">
+            skill radar
+          </p>
+          <SkillRadarChart radar={analysis.skillRadar} size={220} />
+        </TerminalCard>
+      )}
+
+      {/* Patterns */}
+      {analysis.patterns.length > 0 && (
+        <div>
+          <p className="mb-2 text-xs font-medium uppercase text-lofi-muted">
+            patterns detected
+          </p>
+          <div className="space-y-2">
+            {analysis.patterns.map((p, i) => (
+              <TerminalCard key={i} className="!p-3">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`h-2 w-2 rounded-full ${sentimentColors[p.sentiment] ?? "bg-lofi-muted"}`}
+                  />
+                  <span className="text-xs uppercase text-lofi-muted">
+                    {p.category}
+                  </span>
+                </div>
+                <p className="mt-1 text-sm font-medium text-lofi-text">
+                  {p.title}
+                </p>
+                <p className="mt-0.5 text-xs text-lofi-secondary">
+                  {p.detail}
+                </p>
+              </TerminalCard>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Trends */}
+      {analysis.trends.length > 0 && (
+        <div>
+          <p className="mb-2 text-xs font-medium uppercase text-lofi-muted">
+            trends
+          </p>
+          <div className="space-y-1">
+            {analysis.trends.map((t, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-2 text-xs text-lofi-secondary"
+              >
+                <span
+                  className={`text-sm font-bold ${directionColors[t.direction] ?? "text-lofi-muted"}`}
+                >
+                  {directionIcons[t.direction] ?? "?"}
+                </span>
+                <span className="font-medium text-lofi-text">{t.metric}</span>
+                <span>{t.detail}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Improvement Plan */}
+      {analysis.improvementPlan.length > 0 && (
+        <div>
+          <p className="mb-2 text-xs font-medium uppercase text-lofi-muted">
+            improvement plan
+          </p>
+          <div className="space-y-2">
+            {analysis.improvementPlan.map((s, i) => (
+              <div
+                key={i}
+                className="flex items-start gap-3 text-sm text-lofi-secondary"
+              >
+                <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-lofi-accent text-xs font-bold text-lofi-accent">
+                  {i + 1}
+                </span>
+                <div>
+                  <p className="text-lofi-text">{s.description}</p>
+                  <span className="text-xs text-lofi-muted">{s.category}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/coach/match-analysis-button.tsx
+++ b/frontend/src/components/coach/match-analysis-button.tsx
@@ -1,0 +1,37 @@
+import { useAnalyzeMatch } from "@/hooks/use-coach";
+import type { AnalyzeMatchResponse } from "@/gen/tft/v1/coach_pb";
+
+interface MatchAnalysisButtonProps {
+  matchId: string;
+  puuid: string;
+  onAnalysis: (data: AnalyzeMatchResponse) => void;
+}
+
+export function MatchAnalysisButton({
+  matchId,
+  puuid,
+  onAnalysis,
+}: MatchAnalysisButtonProps) {
+  const { mutate, isPending } = useAnalyzeMatch();
+
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        mutate(
+          { matchId, puuid },
+          { onSuccess: (data) => onAnalysis(data) },
+        );
+      }}
+      disabled={isPending}
+      className="shrink-0 rounded-sm border border-lofi-border px-2 py-0.5 text-xs text-lofi-muted transition-colors hover:border-lofi-accent hover:text-lofi-accent disabled:opacity-50"
+      title="AI Coach Analysis"
+    >
+      {isPending ? (
+        <span className="animate-pulse">analyzing...</span>
+      ) : (
+        "analyze"
+      )}
+    </button>
+  );
+}

--- a/frontend/src/components/coach/match-analysis-panel.tsx
+++ b/frontend/src/components/coach/match-analysis-panel.tsx
@@ -1,0 +1,148 @@
+import { TerminalCard } from "@/components/ui/terminal-card";
+import type { AnalyzeMatchResponse } from "@/gen/tft/v1/coach_pb";
+
+interface MatchAnalysisPanelProps {
+  analysis: AnalyzeMatchResponse;
+}
+
+const gradeColors: Record<string, string> = {
+  "S+": "text-yellow-400 border-yellow-400",
+  S: "text-yellow-400 border-yellow-400",
+  "A+": "text-green-400 border-green-400",
+  A: "text-green-400 border-green-400",
+  "B+": "text-blue-400 border-blue-400",
+  B: "text-blue-400 border-blue-400",
+  "C+": "text-orange-400 border-orange-400",
+  C: "text-orange-400 border-orange-400",
+  D: "text-red-400 border-red-400",
+  F: "text-red-500 border-red-500",
+};
+
+const insightGradeColors: Record<string, string> = {
+  good: "bg-green-500",
+  okay: "bg-yellow-500",
+  poor: "bg-red-500",
+};
+
+export function MatchAnalysisPanel({ analysis }: MatchAnalysisPanelProps) {
+  const gradeColor =
+    gradeColors[analysis.overallGrade] ?? "text-lofi-muted border-lofi-muted";
+
+  return (
+    <div className="mt-2 space-y-3 border-l-2 border-lofi-accent/30 pl-4">
+      {/* Grade + Summary */}
+      <div className="flex items-start gap-3">
+        <div
+          className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-sm border-2 text-lg font-bold ${gradeColor}`}
+        >
+          {analysis.overallGrade}
+        </div>
+        <p className="text-sm text-lofi-secondary">{analysis.summary}</p>
+      </div>
+
+      {/* Insights Grid */}
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {analysis.insights.map((insight) => (
+          <TerminalCard key={insight.category} className="!p-3">
+            <div className="flex items-center gap-2">
+              <span
+                className={`h-2 w-2 rounded-full ${insightGradeColors[insight.grade] ?? "bg-lofi-muted"}`}
+              />
+              <span className="text-xs font-medium uppercase text-lofi-muted">
+                {insight.category}
+              </span>
+            </div>
+            <p className="mt-1 text-sm font-medium text-lofi-text">
+              {insight.title}
+            </p>
+            <p className="mt-0.5 text-xs text-lofi-secondary">
+              {insight.detail}
+            </p>
+          </TerminalCard>
+        ))}
+      </div>
+
+      {/* Meta Comparison */}
+      {analysis.metaComparison && (
+        <TerminalCard className="!p-3">
+          <p className="text-xs font-medium uppercase text-lofi-muted">
+            meta comparison
+          </p>
+          <p className="mt-1 text-sm text-lofi-text">
+            Closest comp:{" "}
+            <span className="font-medium text-lofi-accent">
+              {analysis.metaComparison.closestMetaComp}
+            </span>{" "}
+            ({analysis.metaComparison.metaTier}-tier)
+          </p>
+          {analysis.metaComparison.missingUnits.length > 0 && (
+            <p className="mt-1 text-xs text-lofi-secondary">
+              Missing: {analysis.metaComparison.missingUnits.join(", ")}
+            </p>
+          )}
+          {analysis.metaComparison.suboptimalItems.length > 0 && (
+            <p className="text-xs text-lofi-secondary">
+              Suboptimal items:{" "}
+              {analysis.metaComparison.suboptimalItems.join(", ")}
+            </p>
+          )}
+          <p className="mt-1 text-xs text-lofi-secondary">
+            {analysis.metaComparison.assessment}
+          </p>
+        </TerminalCard>
+      )}
+
+      {/* Lobby Context */}
+      {analysis.lobbyContext && (
+        <TerminalCard className="!p-3">
+          <p className="text-xs font-medium uppercase text-lofi-muted">
+            lobby context
+          </p>
+          <p className="mt-1 text-sm text-lofi-text">
+            {analysis.lobbyContext.contestedCount > 0
+              ? `${analysis.lobbyContext.contestedCount} player(s) contested your comp`
+              : "Your comp was uncontested"}
+          </p>
+          <p className="mt-0.5 text-xs text-lofi-secondary">
+            {analysis.lobbyContext.lobbyStrengthAssessment}
+          </p>
+          {analysis.lobbyContext.contestedDetails.map((detail, i) => (
+            <p key={i} className="text-xs text-lofi-muted">
+              {detail}
+            </p>
+          ))}
+        </TerminalCard>
+      )}
+
+      {/* Suggestions */}
+      {analysis.suggestions.length > 0 && (
+        <div>
+          <p className="mb-1 text-xs font-medium uppercase text-lofi-muted">
+            suggestions
+          </p>
+          <div className="space-y-1">
+            {analysis.suggestions.map((s, i) => (
+              <div
+                key={i}
+                className="flex items-start gap-2 text-xs text-lofi-secondary"
+              >
+                <span
+                  className={`mt-0.5 shrink-0 rounded-sm px-1 py-0.5 text-[10px] font-medium uppercase ${
+                    s.priority === "high"
+                      ? "bg-red-500/20 text-red-400"
+                      : s.priority === "medium"
+                        ? "bg-yellow-500/20 text-yellow-400"
+                        : "bg-blue-500/20 text-blue-400"
+                  }`}
+                >
+                  {s.priority}
+                </span>
+                <span>{s.description}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/coach/match-detail-analysis.tsx
+++ b/frontend/src/components/coach/match-detail-analysis.tsx
@@ -1,0 +1,351 @@
+import { TerminalCard } from "@/components/ui/terminal-card";
+import { PlacementBadge } from "@/components/player/placement-badge";
+import { UnitIcon } from "@/components/player/unit-icon";
+import { TraitBadge } from "@/components/player/trait-badge";
+import type { Match, Participant } from "@/gen/tft/v1/player_pb";
+import type { AnalyzeMatchResponse } from "@/gen/tft/v1/coach_pb";
+import type { PatchLookup } from "@/hooks/use-patch-lookup";
+
+interface MatchDetailAnalysisProps {
+  match: Match;
+  playerPuuid: string;
+  patchLookup: PatchLookup;
+  analysis: AnalyzeMatchResponse;
+}
+
+const gradeColors: Record<string, string> = {
+  "S+": "text-yellow-400 border-yellow-400",
+  S: "text-yellow-400 border-yellow-400",
+  "A+": "text-green-400 border-green-400",
+  A: "text-green-400 border-green-400",
+  "B+": "text-blue-400 border-blue-400",
+  B: "text-blue-400 border-blue-400",
+  "C+": "text-orange-400 border-orange-400",
+  C: "text-orange-400 border-orange-400",
+  D: "text-red-400 border-red-400",
+  F: "text-red-500 border-red-500",
+};
+
+const insightGradeColors: Record<string, string> = {
+  good: "bg-green-500",
+  okay: "bg-yellow-500",
+  poor: "bg-red-500",
+};
+
+function formatRound(lastRound: number): string {
+  if (lastRound <= 3) return `1-${lastRound}`;
+  const adjusted = lastRound - 3;
+  const stage = Math.floor(adjusted / 7) + 2;
+  const round = (adjusted % 7) + 1;
+  return `${stage}-${round}`;
+}
+
+export function MatchDetailAnalysis({
+  match,
+  playerPuuid,
+  patchLookup,
+  analysis,
+}: MatchDetailAnalysisProps) {
+  const info = match.info;
+  if (!info) return null;
+
+  const player = info.participants.find((p) => p.puuid === playerPuuid);
+  if (!player) return null;
+
+  const gradeColor =
+    gradeColors[analysis.overallGrade] ?? "text-lofi-muted border-lofi-muted";
+
+  const gameLengthMin = (info.gameLength / 60).toFixed(0);
+  const activeTraits = player.traits
+    .filter((t) => t.style > 0)
+    .sort((a, b) => b.style - a.style);
+  const sortedUnits = [...player.units].sort(
+    (a, b) => b.rarity - a.rarity || b.tier - a.tier,
+  );
+
+  const lobbyParticipants = [...info.participants].sort(
+    (a, b) => a.placement - b.placement,
+  );
+
+  return (
+    <div className="mt-2 space-y-4 border-l-2 border-lofi-accent/30 pl-4">
+      {/* ── Header: Grade + Summary ── */}
+      <div className="flex items-start gap-4">
+        <div
+          className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-sm border-2 text-xl font-bold ${gradeColor}`}
+        >
+          {analysis.overallGrade}
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm text-lofi-secondary">{analysis.summary}</p>
+          <div className="mt-1 flex flex-wrap gap-3 text-[10px] text-lofi-muted">
+            <span>placement: {player.placement}/8</span>
+            <span>level: {player.level}</span>
+            <span>gold left: {player.goldLeft}</span>
+            <span>round: {formatRound(player.lastRound)}</span>
+            <span>damage: {player.totalDamageToPlayers}</span>
+            <span>duration: {gameLengthMin}m</span>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Your Board ── */}
+      <TerminalCard className="!p-3">
+        <p className="mb-2 text-xs font-medium uppercase text-lofi-muted">
+          your board
+        </p>
+
+        {/* Champions with full detail */}
+        <div className="flex flex-wrap gap-2">
+          {sortedUnits.map((unit, i) => (
+            <div key={i} className="flex flex-col items-center">
+              <UnitIcon unit={unit} lookup={patchLookup} />
+              <span className="mt-0.5 text-[9px] text-lofi-muted">
+                {patchLookup.championByApiName.get(unit.characterId)?.name ??
+                  unit.characterId.replace(/^TFT\d+_/, "")}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Augments */}
+        {player.augments.length > 0 && (
+          <div className="mt-3">
+            <p className="mb-1 text-[10px] uppercase text-lofi-muted">
+              augments
+            </p>
+            <div className="flex flex-wrap gap-1">
+              {player.augments.map((aug) => {
+                const item = patchLookup.itemByApiName.get(aug);
+                return (
+                  <div
+                    key={aug}
+                    className="flex items-center gap-1 rounded border border-lofi-border bg-lofi-black px-1.5 py-0.5"
+                  >
+                    {item?.iconUrl && (
+                      <img
+                        src={item.iconUrl}
+                        alt={item.name}
+                        className="h-4 w-4"
+                        loading="lazy"
+                      />
+                    )}
+                    <span className="text-[10px] text-lofi-secondary">
+                      {item?.name ?? aug.replace(/^TFT\d+_/, "")}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Active Traits */}
+        <div className="mt-3">
+          <p className="mb-1 text-[10px] uppercase text-lofi-muted">
+            active traits
+          </p>
+          <div className="flex flex-wrap gap-1">
+            {activeTraits.map((trait) => (
+              <TraitBadge
+                key={trait.apiName}
+                trait={trait}
+                lookup={patchLookup}
+              />
+            ))}
+          </div>
+        </div>
+      </TerminalCard>
+
+      {/* ── Coaching Insights ── */}
+      <div>
+        <p className="mb-2 text-xs font-medium uppercase text-lofi-muted">
+          coaching insights
+        </p>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {analysis.insights.map((insight) => (
+            <TerminalCard key={insight.category} className="!p-3">
+              <div className="flex items-center gap-2">
+                <span
+                  className={`h-2 w-2 rounded-full ${insightGradeColors[insight.grade] ?? "bg-lofi-muted"}`}
+                />
+                <span className="text-xs font-medium uppercase text-lofi-muted">
+                  {insight.category}
+                </span>
+              </div>
+              <p className="mt-1 text-sm font-medium text-lofi-text">
+                {insight.title}
+              </p>
+              <p className="mt-0.5 text-xs text-lofi-secondary">
+                {insight.detail}
+              </p>
+            </TerminalCard>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Meta Comparison ── */}
+      {analysis.metaComparison && (
+        <TerminalCard className="!p-3">
+          <p className="mb-1 text-xs font-medium uppercase text-lofi-muted">
+            meta comparison
+          </p>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-lofi-accent">
+              {analysis.metaComparison.closestMetaComp}
+            </span>
+            <span className="rounded border border-lofi-border px-1.5 py-0.5 text-[10px] font-bold text-lofi-secondary">
+              {analysis.metaComparison.metaTier}-tier
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-lofi-secondary">
+            {analysis.metaComparison.assessment}
+          </p>
+          {analysis.metaComparison.missingUnits.length > 0 && (
+            <div className="mt-2">
+              <span className="text-[10px] uppercase text-lofi-muted">
+                missing units:{" "}
+              </span>
+              <span className="text-xs text-red-400">
+                {analysis.metaComparison.missingUnits.join(", ")}
+              </span>
+            </div>
+          )}
+          {analysis.metaComparison.suboptimalItems.length > 0 && (
+            <div>
+              <span className="text-[10px] uppercase text-lofi-muted">
+                suboptimal items:{" "}
+              </span>
+              <span className="text-xs text-orange-400">
+                {analysis.metaComparison.suboptimalItems.join(", ")}
+              </span>
+            </div>
+          )}
+        </TerminalCard>
+      )}
+
+      {/* ── Lobby Overview ── */}
+      <div>
+        <p className="mb-2 text-xs font-medium uppercase text-lofi-muted">
+          lobby ({analysis.lobbyContext
+            ? `${analysis.lobbyContext.contestedCount} contested`
+            : "8 players"})
+        </p>
+        {analysis.lobbyContext && (
+          <p className="mb-2 text-xs text-lofi-secondary">
+            {analysis.lobbyContext.lobbyStrengthAssessment}
+          </p>
+        )}
+        <TerminalCard className="!p-3">
+          <div className="space-y-1.5">
+            {lobbyParticipants.map((p) => (
+              <LobbyRow
+                key={p.puuid}
+                participant={p}
+                isPlayer={p.puuid === playerPuuid}
+                patchLookup={patchLookup}
+              />
+            ))}
+          </div>
+        </TerminalCard>
+      </div>
+
+      {/* ── Suggestions ── */}
+      {analysis.suggestions.length > 0 && (
+        <div>
+          <p className="mb-2 text-xs font-medium uppercase text-lofi-muted">
+            what to improve next game
+          </p>
+          <div className="space-y-2">
+            {analysis.suggestions.map((s, i) => (
+              <div
+                key={i}
+                className="flex items-start gap-3 text-sm"
+              >
+                <span
+                  className={`mt-0.5 shrink-0 rounded-sm px-1.5 py-0.5 text-[10px] font-bold uppercase ${
+                    s.priority === "high"
+                      ? "bg-red-500/20 text-red-400"
+                      : s.priority === "medium"
+                        ? "bg-yellow-500/20 text-yellow-400"
+                        : "bg-blue-500/20 text-blue-400"
+                  }`}
+                >
+                  {s.priority}
+                </span>
+                <div>
+                  <p className="text-xs text-lofi-text">{s.description}</p>
+                  <span className="text-[10px] text-lofi-muted">
+                    {s.category}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Lobby Row ──
+
+function LobbyRow({
+  participant,
+  isPlayer,
+  patchLookup,
+}: {
+  participant: Participant;
+  isPlayer: boolean;
+  patchLookup: PatchLookup;
+}) {
+  const activeTraits = participant.traits
+    .filter((t) => t.style > 0)
+    .sort((a, b) => b.style - a.style);
+  const sortedUnits = [...participant.units].sort(
+    (a, b) => b.rarity - a.rarity || b.tier - a.tier,
+  );
+
+  return (
+    <div
+      className={`flex items-center gap-2 rounded-sm px-2 py-1.5 ${
+        isPlayer
+          ? "border border-lofi-accent/30 bg-lofi-accent/5"
+          : "hover:bg-lofi-surface/50"
+      }`}
+    >
+      <PlacementBadge placement={participant.placement} />
+
+      <div className="w-[60px] shrink-0">
+        <p className="text-[10px] text-lofi-muted">
+          lv{participant.level} // {participant.goldLeft}g
+        </p>
+        <p className="text-[10px] text-lofi-muted">
+          {participant.totalDamageToPlayers} dmg
+        </p>
+      </div>
+
+      <div className="flex w-[90px] shrink-0 flex-wrap gap-0.5">
+        {activeTraits.slice(0, 4).map((trait) => (
+          <TraitBadge
+            key={trait.apiName}
+            trait={trait}
+            lookup={patchLookup}
+          />
+        ))}
+      </div>
+
+      <div className="flex min-w-0 flex-1 items-start gap-1 overflow-x-auto">
+        {sortedUnits.map((unit, i) => (
+          <UnitIcon key={i} unit={unit} lookup={patchLookup} />
+        ))}
+      </div>
+
+      {isPlayer && (
+        <span className="shrink-0 text-[9px] font-bold uppercase text-lofi-accent">
+          you
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/coach/match-detail-screen.tsx
+++ b/frontend/src/components/coach/match-detail-screen.tsx
@@ -1,0 +1,475 @@
+import { useState, useEffect } from "react";
+import { TerminalCard } from "@/components/ui/terminal-card";
+import { PlacementBadge } from "@/components/player/placement-badge";
+import { UnitIcon } from "@/components/player/unit-icon";
+import { TraitBadge } from "@/components/player/trait-badge";
+import { useGetMatchAnalysis, useAnalyzeMatch } from "@/hooks/use-coach";
+import type { Match, Participant } from "@/gen/tft/v1/player_pb";
+import type { AnalyzeMatchResponse } from "@/gen/tft/v1/coach_pb";
+import type { PatchLookup } from "@/hooks/use-patch-lookup";
+
+interface MatchDetailScreenProps {
+  match: Match;
+  playerPuuid: string;
+  patchLookup: PatchLookup;
+  onBack: () => void;
+}
+
+const gradeColors: Record<string, string> = {
+  "S+": "text-yellow-400 border-yellow-400",
+  S: "text-yellow-400 border-yellow-400",
+  "A+": "text-green-400 border-green-400",
+  A: "text-green-400 border-green-400",
+  "B+": "text-blue-400 border-blue-400",
+  B: "text-blue-400 border-blue-400",
+  "C+": "text-orange-400 border-orange-400",
+  C: "text-orange-400 border-orange-400",
+  D: "text-red-400 border-red-400",
+  F: "text-red-500 border-red-500",
+};
+
+const insightGradeColors: Record<string, string> = {
+  good: "bg-green-500",
+  okay: "bg-yellow-500",
+  poor: "bg-red-500",
+};
+
+function formatRound(lastRound: number): string {
+  if (lastRound <= 3) return `1-${lastRound}`;
+  const adjusted = lastRound - 3;
+  const stage = Math.floor(adjusted / 7) + 2;
+  const round = (adjusted % 7) + 1;
+  return `${stage}-${round}`;
+}
+
+function getTimeAgo(date: Date): string {
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function MatchDetailScreen({
+  match,
+  playerPuuid,
+  patchLookup,
+  onBack,
+}: MatchDetailScreenProps) {
+  const info = match.info;
+  const metadata = match.metadata;
+  const matchId = metadata?.matchId ?? "";
+
+  const [analysis, setAnalysis] = useState<AnalyzeMatchResponse | null>(null);
+  const cachedQuery = useGetMatchAnalysis(matchId, playerPuuid);
+  const analyzeMutation = useAnalyzeMatch();
+
+  // Load cached analysis on mount
+  useEffect(() => {
+    if (cachedQuery.data?.found && cachedQuery.data.analysis) {
+      setAnalysis(cachedQuery.data.analysis);
+    }
+  }, [cachedQuery.data]);
+
+  if (!info || !metadata) return null;
+
+  const player = info.participants.find((p) => p.puuid === playerPuuid);
+  if (!player) return null;
+
+  const gameDate = new Date(Number(info.gameDatetime));
+  const gameLengthMin = (info.gameLength / 60).toFixed(0);
+
+  const activeTraits = player.traits
+    .filter((t) => t.style > 0)
+    .sort((a, b) => b.style - a.style);
+  const sortedUnits = [...player.units].sort(
+    (a, b) => b.rarity - a.rarity || b.tier - a.tier,
+  );
+  const lobbyParticipants = [...info.participants].sort(
+    (a, b) => a.placement - b.placement,
+  );
+
+  const handleAnalyze = (force = false) => {
+    analyzeMutation.mutate(
+      { matchId, puuid: playerPuuid, force },
+      { onSuccess: (data) => setAnalysis(data) },
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* ── Back + Header ── */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={onBack}
+          className="text-xs text-lofi-muted transition-colors hover:text-lofi-text"
+        >
+          &larr; back
+        </button>
+        <div className="h-px flex-1 bg-lofi-border" />
+        <span className="text-[10px] text-lofi-muted">
+          {getTimeAgo(gameDate)} // {gameLengthMin}m //
+          {info.tftGameType === "standard" ? " ranked" : ` ${info.tftGameType}`}
+        </span>
+      </div>
+
+      {/* ── Match Summary Bar ── */}
+      <div className="flex items-center gap-4">
+        <PlacementBadge placement={player.placement} size="md" />
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-lofi-secondary">
+          <span>
+            level <span className="font-medium text-lofi-text">{player.level}</span>
+          </span>
+          <span>
+            gold <span className="font-medium text-lofi-text">{player.goldLeft}</span>
+          </span>
+          <span>
+            round{" "}
+            <span className="font-medium text-lofi-text">
+              {formatRound(player.lastRound)}
+            </span>
+          </span>
+          <span>
+            damage{" "}
+            <span className="font-medium text-lofi-text">
+              {player.totalDamageToPlayers}
+            </span>
+          </span>
+          {player.playersEliminated > 0 && (
+            <span>
+              kills{" "}
+              <span className="font-medium text-red-400">
+                {player.playersEliminated}
+              </span>
+            </span>
+          )}
+        </div>
+
+        <div className="flex-1" />
+
+        {/* Analyze / Re-analyze button + Grade */}
+        {analysis ? (
+          <div className="flex shrink-0 items-center gap-2">
+            <button
+              onClick={() => handleAnalyze(true)}
+              disabled={analyzeMutation.isPending}
+              className="rounded-sm px-3 py-1.5 text-[10px] text-lofi-muted transition-colors hover:text-lofi-accent disabled:opacity-50"
+            >
+              {analyzeMutation.isPending ? (
+                <span className="animate-pulse">re-analyzing...</span>
+              ) : (
+                "re-analyze"
+              )}
+            </button>
+            <div
+              className={`flex h-11 w-11 items-center justify-center rounded-sm border-2 text-lg font-bold ${
+                gradeColors[analysis.overallGrade] ??
+                "text-lofi-muted border-lofi-muted"
+              }`}
+            >
+              {analysis.overallGrade}
+            </div>
+          </div>
+        ) : (
+          <button
+            onClick={() => handleAnalyze()}
+            disabled={analyzeMutation.isPending || cachedQuery.isLoading}
+            className="shrink-0 rounded-sm border border-lofi-accent px-4 py-2 text-xs font-medium text-lofi-accent transition-colors hover:bg-lofi-accent hover:text-lofi-bg disabled:opacity-50"
+          >
+            {analyzeMutation.isPending ? (
+              <span className="animate-pulse">analyzing...</span>
+            ) : cachedQuery.isLoading ? (
+              <span className="animate-pulse">loading...</span>
+            ) : (
+              "analyze match"
+            )}
+          </button>
+        )}
+      </div>
+
+      {analyzeMutation.isError && (
+        <p className="text-xs text-red-400">
+          {analyzeMutation.error?.message ?? "Analysis failed"}
+        </p>
+      )}
+
+      {/* ── AI Summary (when analyzed) ── */}
+      {analysis && (
+        <TerminalCard className="border-lofi-accent/30">
+          <p className="mb-1 text-[10px] font-medium uppercase text-lofi-accent">
+            ai coach
+          </p>
+          <p className="text-sm text-lofi-secondary">{analysis.summary}</p>
+        </TerminalCard>
+      )}
+
+      {/* ── Your Board ── */}
+      <TerminalCard className="!p-3">
+        <p className="mb-2 text-xs font-medium uppercase text-lofi-muted">
+          your board
+        </p>
+
+        <div className="flex flex-wrap gap-3">
+          {sortedUnits.map((unit, i) => {
+            const champ = patchLookup.championByApiName.get(unit.characterId);
+            return (
+              <div key={i} className="flex flex-col items-center">
+                <UnitIcon unit={unit} lookup={patchLookup} />
+                <span className="mt-0.5 max-w-[52px] truncate text-center text-[9px] text-lofi-muted">
+                  {champ?.name ?? unit.characterId.replace(/^TFT\d+_/, "")}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Augments */}
+        {player.augments.length > 0 && (
+          <div className="mt-3">
+            <p className="mb-1 text-[10px] uppercase text-lofi-muted">
+              augments
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {player.augments.map((aug) => {
+                const item = patchLookup.itemByApiName.get(aug);
+                return (
+                  <div
+                    key={aug}
+                    className="flex items-center gap-1.5 rounded border border-lofi-border bg-lofi-black px-2 py-1"
+                  >
+                    {item?.iconUrl && (
+                      <img
+                        src={item.iconUrl}
+                        alt={item.name}
+                        className="h-4 w-4"
+                        loading="lazy"
+                      />
+                    )}
+                    <span className="text-xs text-lofi-secondary">
+                      {item?.name ?? aug.replace(/^TFT\d+_/, "")}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Active Traits */}
+        <div className="mt-3">
+          <p className="mb-1 text-[10px] uppercase text-lofi-muted">
+            active traits
+          </p>
+          <div className="flex flex-wrap gap-1">
+            {activeTraits.map((trait) => (
+              <TraitBadge
+                key={trait.apiName}
+                trait={trait}
+                lookup={patchLookup}
+              />
+            ))}
+          </div>
+        </div>
+      </TerminalCard>
+
+      {/* ── Coaching Insights (when analyzed) ── */}
+      {analysis && analysis.insights.length > 0 && (
+        <div>
+          <p className="mb-2 text-xs font-medium uppercase text-lofi-muted">
+            coaching insights
+          </p>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {analysis.insights.map((insight) => (
+              <TerminalCard key={insight.category} className="!p-3">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`h-2 w-2 rounded-full ${insightGradeColors[insight.grade] ?? "bg-lofi-muted"}`}
+                  />
+                  <span className="text-xs font-medium uppercase text-lofi-muted">
+                    {insight.category}
+                  </span>
+                </div>
+                <p className="mt-1 text-sm font-medium text-lofi-text">
+                  {insight.title}
+                </p>
+                <p className="mt-0.5 text-xs text-lofi-secondary">
+                  {insight.detail}
+                </p>
+              </TerminalCard>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Meta Comparison (when analyzed) ── */}
+      {analysis?.metaComparison && (
+        <TerminalCard className="!p-3">
+          <p className="mb-1 text-xs font-medium uppercase text-lofi-muted">
+            meta comparison
+          </p>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-lofi-accent">
+              {analysis.metaComparison.closestMetaComp}
+            </span>
+            <span className="rounded border border-lofi-border px-1.5 py-0.5 text-[10px] font-bold text-lofi-secondary">
+              {analysis.metaComparison.metaTier}-tier
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-lofi-secondary">
+            {analysis.metaComparison.assessment}
+          </p>
+          {analysis.metaComparison.missingUnits.length > 0 && (
+            <div className="mt-2">
+              <span className="text-[10px] uppercase text-lofi-muted">
+                missing:{" "}
+              </span>
+              <span className="text-xs text-red-400">
+                {analysis.metaComparison.missingUnits.join(", ")}
+              </span>
+            </div>
+          )}
+          {analysis.metaComparison.suboptimalItems.length > 0 && (
+            <div>
+              <span className="text-[10px] uppercase text-lofi-muted">
+                suboptimal items:{" "}
+              </span>
+              <span className="text-xs text-orange-400">
+                {analysis.metaComparison.suboptimalItems.join(", ")}
+              </span>
+            </div>
+          )}
+        </TerminalCard>
+      )}
+
+      {/* ── Lobby ── */}
+      <div>
+        <div className="mb-2 flex items-center gap-2">
+          <p className="text-xs font-medium uppercase text-lofi-muted">
+            lobby
+          </p>
+          {analysis?.lobbyContext && (
+            <span className="text-[10px] text-lofi-muted">
+              // {analysis.lobbyContext.contestedCount > 0
+                ? `${analysis.lobbyContext.contestedCount} contested`
+                : "uncontested"}
+            </span>
+          )}
+        </div>
+        {analysis?.lobbyContext && (
+          <p className="mb-2 text-xs text-lofi-secondary">
+            {analysis.lobbyContext.lobbyStrengthAssessment}
+          </p>
+        )}
+        <TerminalCard className="!p-2">
+          <div className="space-y-1">
+            {lobbyParticipants.map((p) => (
+              <LobbyRow
+                key={p.puuid}
+                participant={p}
+                isPlayer={p.puuid === playerPuuid}
+                patchLookup={patchLookup}
+              />
+            ))}
+          </div>
+        </TerminalCard>
+      </div>
+
+      {/* ── Suggestions (when analyzed) ── */}
+      {analysis && analysis.suggestions.length > 0 && (
+        <div>
+          <p className="mb-2 text-xs font-medium uppercase text-lofi-muted">
+            what to improve next game
+          </p>
+          <div className="space-y-2">
+            {analysis.suggestions.map((s, i) => (
+              <div key={i} className="flex items-start gap-3">
+                <span
+                  className={`mt-0.5 shrink-0 rounded-sm px-1.5 py-0.5 text-[10px] font-bold uppercase ${
+                    s.priority === "high"
+                      ? "bg-red-500/20 text-red-400"
+                      : s.priority === "medium"
+                        ? "bg-yellow-500/20 text-yellow-400"
+                        : "bg-blue-500/20 text-blue-400"
+                  }`}
+                >
+                  {s.priority}
+                </span>
+                <div>
+                  <p className="text-xs text-lofi-text">{s.description}</p>
+                  <span className="text-[10px] text-lofi-muted">
+                    {s.category}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Lobby Row ──
+
+function LobbyRow({
+  participant,
+  isPlayer,
+  patchLookup,
+}: {
+  participant: Participant;
+  isPlayer: boolean;
+  patchLookup: PatchLookup;
+}) {
+  const activeTraits = participant.traits
+    .filter((t) => t.style > 0)
+    .sort((a, b) => b.style - a.style);
+  const sortedUnits = [...participant.units].sort(
+    (a, b) => b.rarity - a.rarity || b.tier - a.tier,
+  );
+
+  return (
+    <div
+      className={`flex items-center gap-2 rounded-sm px-2 py-1.5 ${
+        isPlayer
+          ? "border border-lofi-accent/30 bg-lofi-accent/5"
+          : "hover:bg-lofi-surface/50"
+      }`}
+    >
+      <PlacementBadge placement={participant.placement} />
+
+      <div className="w-[60px] shrink-0">
+        <p className="text-[10px] text-lofi-muted">
+          lv{participant.level} // {participant.goldLeft}g
+        </p>
+        <p className="text-[10px] text-lofi-muted">
+          {participant.totalDamageToPlayers} dmg
+        </p>
+      </div>
+
+      <div className="flex w-[90px] shrink-0 flex-wrap gap-0.5">
+        {activeTraits.slice(0, 4).map((trait) => (
+          <TraitBadge
+            key={trait.apiName}
+            trait={trait}
+            lookup={patchLookup}
+          />
+        ))}
+      </div>
+
+      <div className="flex min-w-0 flex-1 items-start gap-1 overflow-x-auto">
+        {sortedUnits.map((unit, i) => (
+          <UnitIcon key={i} unit={unit} lookup={patchLookup} />
+        ))}
+      </div>
+
+      {isPlayer && (
+        <span className="shrink-0 text-[9px] font-bold uppercase text-lofi-accent">
+          you
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/coach/skill-radar-chart.tsx
+++ b/frontend/src/components/coach/skill-radar-chart.tsx
@@ -1,0 +1,169 @@
+import type { SkillRadar } from "@/gen/tft/v1/coach_pb";
+
+interface SkillRadarChartProps {
+  radar: SkillRadar;
+  size?: number;
+}
+
+const LABELS = ["economy", "itemization", "composition", "adaptability", "consistency"];
+const N = 5;
+const ANGLE_OFFSET = -Math.PI / 2;
+
+function getAngle(i: number): number {
+  return ANGLE_OFFSET + (2 * Math.PI * i) / N;
+}
+
+function polarToCartesian(cx: number, cy: number, r: number, angle: number) {
+  return {
+    x: cx + r * Math.cos(angle),
+    y: cy + r * Math.sin(angle),
+  };
+}
+
+function clamp(v: number): number {
+  return Math.min(Math.max(v, 0), 100);
+}
+
+export function SkillRadarChart({ radar, size = 200 }: SkillRadarChartProps) {
+  const cx = size / 2;
+  const cy = size / 2;
+  const maxR = size * 0.38;
+  const labelR = size * 0.48;
+
+  const values: number[] = [
+    radar.economy,
+    radar.itemization,
+    radar.composition,
+    radar.adaptability,
+    radar.consistency,
+  ];
+
+  const items = values.map((v, i) => ({
+    value: v,
+    angle: getAngle(i),
+    label: LABELS[i] ?? "",
+  }));
+
+  const rings = [0.25, 0.5, 0.75, 1.0];
+
+  // Data polygon points
+  const dataPoints = items
+    .map((item) => {
+      const r = (clamp(item.value) / 100) * maxR;
+      const p = polarToCartesian(cx, cy, r, item.angle);
+      return `${p.x},${p.y}`;
+    })
+    .join(" ");
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      className="block"
+    >
+      {/* Grid rings */}
+      {rings.map((scale) => {
+        const pts = items
+          .map((item) => {
+            const p = polarToCartesian(cx, cy, maxR * scale, item.angle);
+            return `${p.x},${p.y}`;
+          })
+          .join(" ");
+        return (
+          <polygon
+            key={scale}
+            points={pts}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={0.5}
+            className="text-lofi-border"
+          />
+        );
+      })}
+
+      {/* Axis lines */}
+      {items.map((item, i) => {
+        const p = polarToCartesian(cx, cy, maxR, item.angle);
+        return (
+          <line
+            key={i}
+            x1={cx}
+            y1={cy}
+            x2={p.x}
+            y2={p.y}
+            stroke="currentColor"
+            strokeWidth={0.5}
+            className="text-lofi-border"
+          />
+        );
+      })}
+
+      {/* Data polygon */}
+      <polygon
+        points={dataPoints}
+        fill="currentColor"
+        fillOpacity={0.15}
+        stroke="currentColor"
+        strokeWidth={1.5}
+        className="text-lofi-accent"
+      />
+
+      {/* Data points */}
+      {items.map((item, i) => {
+        const r = (clamp(item.value) / 100) * maxR;
+        const p = polarToCartesian(cx, cy, r, item.angle);
+        return (
+          <circle
+            key={i}
+            cx={p.x}
+            cy={p.y}
+            r={2.5}
+            fill="currentColor"
+            className="text-lofi-accent"
+          />
+        );
+      })}
+
+      {/* Labels */}
+      {items.map((item) => {
+        const p = polarToCartesian(cx, cy, labelR, item.angle);
+        return (
+          <text
+            key={item.label}
+            x={p.x}
+            y={p.y}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            fill="currentColor"
+            className="text-lofi-muted"
+            fontSize={10}
+          >
+            {item.label}
+          </text>
+        );
+      })}
+
+      {/* Value labels */}
+      {items.map((item, i) => {
+        const r = (clamp(item.value) / 100) * maxR + 10;
+        const p = polarToCartesian(cx, cy, r, item.angle);
+        return (
+          <text
+            key={`val-${i}`}
+            x={p.x}
+            y={p.y}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            fill="currentColor"
+            className="text-lofi-secondary"
+            fontSize={9}
+            fontWeight="bold"
+          >
+            {Math.round(item.value)}
+          </text>
+        );
+      })}
+    </svg>
+  );
+}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -6,6 +6,7 @@ const navItems = [
   { to: "/items", label: "items" },
   { to: "/augments", label: "augments" },
   { to: "/simulator", label: "simulator" },
+  { to: "/tier-list", label: "tier list" },
   { to: "/profile", label: "profile" },
   { to: "/player", label: "player search" },
   { to: "/settings", label: "settings" },
@@ -22,7 +23,7 @@ export function Sidebar() {
           TFT_ORACLE
         </h1>
         <p className="mt-0.5 text-[10px] text-lofi-muted">
-          v0.2.0 // phase 2
+          v0.4.0 // phase 4
         </p>
       </div>
 
@@ -79,7 +80,7 @@ export function Sidebar() {
 
       <div className="border-t border-lofi-border px-4 py-3">
         <p className="text-[10px] text-lofi-muted">
-          data: communitydragon + riot api
+          data: communitydragon + riot api + metatft + tftactics + mobalytics
         </p>
       </div>
     </aside>

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -2,12 +2,12 @@ import { NavLink } from "react-router-dom";
 import { useAuthStore } from "@/stores/auth-store";
 
 const navItems = [
+  { to: "/coach", label: "ai coach" },
+  { to: "/simulator", label: "simulator" },
+  { to: "/tier-list", label: "tier list" },
   { to: "/champions", label: "champions" },
   { to: "/items", label: "items" },
   { to: "/augments", label: "augments" },
-  { to: "/simulator", label: "simulator" },
-  { to: "/tier-list", label: "tier list" },
-  { to: "/profile", label: "profile" },
   { to: "/player", label: "player search" },
   { to: "/settings", label: "settings" },
 ];
@@ -18,6 +18,7 @@ export function Sidebar() {
 
   return (
     <aside className="flex h-screen w-64 flex-col border-r border-lofi-border bg-lofi-black">
+      {/* Logo */}
       <div className="border-b border-lofi-border px-4 py-4">
         <h1 className="text-sm font-bold tracking-wider text-white">
           TFT_ORACLE
@@ -27,7 +28,48 @@ export function Sidebar() {
         </p>
       </div>
 
+      {/* Active User Card */}
+      {isLoggedIn && user ? (
+        <div className="border-b border-lofi-border px-3 py-3">
+          <NavLink to="/profile" className="block">
+            <div className="rounded-sm border border-lofi-border bg-lofi-surface px-3 py-2.5 transition-colors hover:border-lofi-muted">
+              <p className="text-[10px] font-medium uppercase tracking-wider text-lofi-muted">
+                active user
+              </p>
+              <p className="mt-1 text-sm font-bold tracking-wide text-white">
+                {user.gameName}
+              </p>
+              <div className="mt-0.5 flex items-center gap-2">
+                <span className="text-[10px] text-lofi-muted">
+                  #{user.tagLine}
+                </span>
+                <span className="text-[10px] text-lofi-muted">
+                  {user.region.toUpperCase()}
+                </span>
+              </div>
+            </div>
+          </NavLink>
+        </div>
+      ) : (
+        <div className="border-b border-lofi-border px-3 py-3">
+          <NavLink to="/auth" className="block">
+            <div className="rounded-sm border border-dashed border-lofi-muted px-3 py-3 text-center transition-colors hover:border-lofi-accent">
+              <p className="text-xs font-medium text-lofi-accent">
+                login / register
+              </p>
+              <p className="mt-0.5 text-[10px] text-lofi-muted">
+                sign in to use ai coach
+              </p>
+            </div>
+          </NavLink>
+        </div>
+      )}
+
+      {/* Navigation */}
       <nav className="flex-1 px-2 py-3">
+        <p className="mb-1 px-3 text-[9px] font-medium uppercase tracking-widest text-lofi-muted">
+          navigation
+        </p>
         {navItems.map((item) => (
           <NavLink
             key={item.to}
@@ -55,33 +97,17 @@ export function Sidebar() {
       </nav>
 
       <div className="border-t border-lofi-border px-4 py-3">
-        {isLoggedIn && user ? (
-          <div className="space-y-1">
-            <p className="text-xs text-lofi-text">
-              {user.gameName}
-              <span className="text-lofi-muted">#{user.tagLine}</span>
-            </p>
-            <button
-              onClick={logout}
-              className="text-[10px] text-lofi-muted hover:text-red-400"
-            >
-              logout
-            </button>
-          </div>
-        ) : (
-          <NavLink
-            to="/auth"
-            className="text-[10px] text-lofi-accent hover:text-lofi-text"
-          >
-            login / register
-          </NavLink>
-        )}
-      </div>
-
-      <div className="border-t border-lofi-border px-4 py-3">
         <p className="text-[10px] text-lofi-muted">
           data: communitydragon + riot api + metatft + tftactics + mobalytics
         </p>
+        {isLoggedIn && (
+          <button
+            onClick={logout}
+            className="mt-2 text-[10px] text-lofi-muted hover:text-red-400"
+          >
+            logout
+          </button>
+        )}
       </div>
     </aside>
   );

--- a/frontend/src/components/tier-list/composition-card.tsx
+++ b/frontend/src/components/tier-list/composition-card.tsx
@@ -1,0 +1,132 @@
+import { TerminalCard } from "@/components/ui/terminal-card";
+import { Badge } from "@/components/ui/badge";
+import { ConfidenceIndicator } from "./confidence-indicator";
+import { SourceBreakdown } from "./source-breakdown";
+import type { TierListEntry } from "@/gen/tft/v1/tierlist_pb";
+import type { Champion, Item } from "@/gen/tft/v1/patch_pb";
+
+const consensusStyles: Record<string, string> = {
+  unanimous: "border-green-500/30 bg-green-500/10 text-green-400",
+  majority: "border-yellow-500/30 bg-yellow-500/10 text-yellow-400",
+  split: "border-red-500/30 bg-red-500/10 text-red-400",
+  single_source: "border-lofi-border bg-lofi-surface text-lofi-muted",
+};
+
+const placementColor = (p: number) =>
+  p > 0 && p <= 4 ? "text-green-400" : "text-red-400";
+
+interface CompositionCardProps {
+  entry: TierListEntry;
+  championMap: Map<string, Champion>;
+  itemMap: Map<string, Item>;
+}
+
+export function CompositionCard({
+  entry,
+  championMap,
+  itemMap,
+}: CompositionCardProps) {
+  return (
+    <TerminalCard>
+      {/* Header */}
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Badge className="font-bold">{entry.consolidatedTier}</Badge>
+          <span className="text-xs font-medium text-white">
+            {entry.compositionName}
+          </span>
+        </div>
+        <ConfidenceIndicator level={entry.confidence} />
+      </div>
+
+      {/* Champion portraits */}
+      <div className="mb-3 flex flex-wrap gap-1.5">
+        {entry.coreChampions.map((apiName) => {
+          const champ = championMap.get(apiName);
+          return (
+            <div key={apiName} className="flex flex-col items-center gap-0.5">
+              {champ?.squareIconUrl ? (
+                <img
+                  src={champ.squareIconUrl}
+                  alt={champ.name}
+                  className="h-8 w-8 rounded-sm border border-lofi-border"
+                />
+              ) : (
+                <div className="flex h-8 w-8 items-center justify-center rounded-sm border border-lofi-border bg-lofi-black text-[8px] text-lofi-muted">
+                  {apiName.split("_").pop()?.slice(0, 3)}
+                </div>
+              )}
+              {/* Items for this champion */}
+              <div className="flex gap-0.5">
+                {(entry.recommendedItems[apiName]?.itemApiNames ?? []).map(
+                  (itemApi, idx) => {
+                    const item = itemMap.get(itemApi);
+                    return item?.iconUrl ? (
+                      <img
+                        key={idx}
+                        src={item.iconUrl}
+                        alt={item.name}
+                        className="h-3.5 w-3.5 rounded-sm"
+                      />
+                    ) : (
+                      <div
+                        key={idx}
+                        className="h-3.5 w-3.5 rounded-sm bg-lofi-border"
+                      />
+                    );
+                  },
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Stats row */}
+      <div className="mb-2 flex items-center gap-4 text-[10px]">
+        {entry.avgWinRate > 0 && (
+          <span className="text-lofi-secondary">
+            win{" "}
+            <span className="text-green-400">
+              {entry.avgWinRate.toFixed(1)}%
+            </span>
+          </span>
+        )}
+        {entry.avgPlayRate > 0 && (
+          <span className="text-lofi-secondary">
+            play{" "}
+            <span className="text-lofi-text">
+              {entry.avgPlayRate.toFixed(1)}%
+            </span>
+          </span>
+        )}
+        {entry.avgPlacement > 0 && (
+          <span className="text-lofi-secondary">
+            avg{" "}
+            <span className={placementColor(entry.avgPlacement)}>
+              {entry.avgPlacement.toFixed(2)}
+            </span>
+          </span>
+        )}
+      </div>
+
+      {/* Consensus badge */}
+      <div className="flex items-center gap-2">
+        <span
+          className={`inline-flex items-center rounded-sm border px-1.5 py-0.5 text-[10px] ${
+            consensusStyles[entry.consensus] ?? consensusStyles.split
+          }`}
+        >
+          {entry.consensus}
+        </span>
+      </div>
+
+      {/* Source breakdown */}
+      <SourceBreakdown
+        metatftTier={entry.metatftTier}
+        tftacticsTier={entry.tftacticsTier}
+        mobalyticsTier={entry.mobalyticsTier}
+      />
+    </TerminalCard>
+  );
+}

--- a/frontend/src/components/tier-list/confidence-indicator.tsx
+++ b/frontend/src/components/tier-list/confidence-indicator.tsx
@@ -1,0 +1,20 @@
+const styles: Record<string, string> = {
+  high: "bg-green-500",
+  medium: "bg-yellow-500",
+  low: "bg-red-500",
+};
+
+interface ConfidenceIndicatorProps {
+  level: string;
+}
+
+export function ConfidenceIndicator({ level }: ConfidenceIndicatorProps) {
+  const dotColor = styles[level] ?? styles.low;
+
+  return (
+    <span className="inline-flex items-center gap-1 text-[10px] text-lofi-secondary">
+      <span className={`h-1.5 w-1.5 rounded-full ${dotColor}`} />
+      {level}
+    </span>
+  );
+}

--- a/frontend/src/components/tier-list/crawl-status-footer.tsx
+++ b/frontend/src/components/tier-list/crawl-status-footer.tsx
@@ -1,0 +1,31 @@
+interface CrawlStatusFooterProps {
+  lastUpdated: string;
+}
+
+export function CrawlStatusFooter({ lastUpdated }: CrawlStatusFooterProps) {
+  const formatted = lastUpdated
+    ? formatRelativeTime(lastUpdated)
+    : "never";
+
+  return (
+    <div className="mt-6 border-t border-lofi-border pt-3 text-[10px] text-lofi-muted">
+      last updated: {formatted} // sources: metatft + tftactics + mobalytics
+    </div>
+  );
+}
+
+function formatRelativeTime(iso: string): string {
+  const date = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+
+  const diffD = Math.floor(diffH / 24);
+  return `${diffD}d ago`;
+}

--- a/frontend/src/components/tier-list/source-breakdown.tsx
+++ b/frontend/src/components/tier-list/source-breakdown.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+
+interface SourceBreakdownProps {
+  metatftTier: string;
+  tftacticsTier: string;
+  mobalyticsTier: string;
+}
+
+const sources = [
+  { key: "metatftTier" as const, label: "MetaTFT" },
+  { key: "tftacticsTier" as const, label: "TFTactics" },
+  { key: "mobalyticsTier" as const, label: "Mobalytics" },
+];
+
+export function SourceBreakdown({
+  metatftTier,
+  tftacticsTier,
+  mobalyticsTier,
+}: SourceBreakdownProps) {
+  const [open, setOpen] = useState(false);
+
+  const tiers: Record<string, string> = {
+    metatftTier,
+    tftacticsTier,
+    mobalyticsTier,
+  };
+
+  return (
+    <div className="mt-2 border-t border-lofi-border pt-2">
+      <button
+        onClick={() => setOpen(!open)}
+        className="text-[10px] text-lofi-muted hover:text-lofi-secondary transition-colors"
+      >
+        {open ? "- hide sources" : "+ view sources"}
+      </button>
+
+      {open && (
+        <div className="mt-2 space-y-1">
+          {sources.map((s) => (
+            <div
+              key={s.key}
+              className="flex items-center justify-between text-[10px]"
+            >
+              <span className="text-lofi-muted">{s.label}</span>
+              <span className="text-lofi-secondary">
+                {tiers[s.key] || "—"}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/tier-list/tier-list-skeleton.tsx
+++ b/frontend/src/components/tier-list/tier-list-skeleton.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function TierListSkeleton() {
+  return (
+    <div className="space-y-6">
+      {["S", "A", "B", "C"].map((tier) => (
+        <div key={tier} className="border-l-4 border-l-lofi-border pl-3">
+          <Skeleton className="mb-3 h-6 w-16" />
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+            {Array.from({ length: tier === "S" ? 2 : 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-36" />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/tier-list/tier-section.tsx
+++ b/frontend/src/components/tier-list/tier-section.tsx
@@ -1,0 +1,61 @@
+import type { TierListEntry } from "@/gen/tft/v1/tierlist_pb";
+import type { Champion, Item } from "@/gen/tft/v1/patch_pb";
+import { CompositionCard } from "./composition-card";
+
+const tierStyles: Record<string, string> = {
+  S: "border-l-4 border-l-yellow-500",
+  A: "border-l-4 border-l-green-500",
+  B: "border-l-4 border-l-blue-500",
+  C: "border-l-4 border-l-lofi-muted",
+  D: "border-l-4 border-l-lofi-border",
+};
+
+const tierLabelStyles: Record<string, string> = {
+  S: "text-yellow-500",
+  A: "text-green-500",
+  B: "text-blue-500",
+  C: "text-lofi-muted",
+  D: "text-lofi-border",
+};
+
+interface TierSectionProps {
+  tier: string;
+  entries: TierListEntry[];
+  championMap: Map<string, Champion>;
+  itemMap: Map<string, Item>;
+}
+
+export function TierSection({
+  tier,
+  entries,
+  championMap,
+  itemMap,
+}: TierSectionProps) {
+  if (entries.length === 0) return null;
+
+  return (
+    <div className={`mb-6 rounded-sm pl-3 ${tierStyles[tier] ?? ""}`}>
+      <div className="mb-3 flex items-center gap-2">
+        <span
+          className={`text-lg font-black ${tierLabelStyles[tier] ?? "text-lofi-muted"}`}
+        >
+          {tier}
+        </span>
+        <span className="text-[10px] text-lofi-muted">
+          {entries.length} comp{entries.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        {entries.map((entry) => (
+          <CompositionCard
+            key={entry.compositionName}
+            entry={entry}
+            championMap={championMap}
+            itemMap={itemMap}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -11,7 +11,7 @@ export function Button({
   ...props
 }: ButtonProps) {
   const base =
-    "inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-lofi-accent disabled:pointer-events-none disabled:opacity-50";
+    "inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-lofi-accent disabled:pointer-events-none disabled:opacity-50 active:scale-95";
 
   const variants = {
     primary: "bg-lofi-text text-lofi-black hover:opacity-80",

--- a/frontend/src/components/ui/generic-empty-state.tsx
+++ b/frontend/src/components/ui/generic-empty-state.tsx
@@ -1,0 +1,37 @@
+import { Button } from "@/components/ui/button";
+
+interface GenericEmptyStateProps {
+  title: string;
+  description: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+export function GenericEmptyState({
+  title,
+  description,
+  actionLabel,
+  onAction,
+}: GenericEmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16">
+      <div className="mb-6 flex h-12 w-12 items-center justify-center rounded-lg border border-lofi-border bg-lofi-surface">
+        <span className="text-xl font-bold text-lofi-muted">//</span>
+      </div>
+
+      <h3 className="mb-1 text-xs font-bold uppercase tracking-widest text-lofi-secondary">
+        {title}
+      </h3>
+
+      <p className="mb-6 max-w-xs text-center text-[10px] leading-relaxed text-lofi-muted">
+        {description}
+      </p>
+
+      {actionLabel && onAction && (
+        <Button variant="secondary" onClick={onAction}>
+          {actionLabel}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/inline-error.tsx
+++ b/frontend/src/components/ui/inline-error.tsx
@@ -1,0 +1,22 @@
+import { Button } from "@/components/ui/button";
+
+interface InlineErrorProps {
+  message: string;
+  onRetry?: () => void;
+}
+
+export function InlineError({ message, onRetry }: InlineErrorProps) {
+  return (
+    <div className="flex items-center justify-between rounded-sm border border-red-500/30 bg-red-500/10 px-4 py-3">
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-red-400">!</span>
+        <span className="text-xs text-red-400">{message}</span>
+      </div>
+      {onRetry && (
+        <Button variant="secondary" onClick={onRetry} className="ml-4 text-red-400 border-red-500/30 hover:bg-red-500/10">
+          retry
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/page-transition.tsx
+++ b/frontend/src/components/ui/page-transition.tsx
@@ -13,7 +13,7 @@ export function PageTransition({ children }: { children: React.ReactNode }) {
 
   return (
     <div
-      className={`transition-all duration-200 ease-out ${
+      className={`will-change-transform transition-all duration-200 ease-out ${
         visible ? "translate-y-0 opacity-100" : "translate-y-1 opacity-0"
       }`}
     >

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -1,15 +1,23 @@
 import { useState, useEffect, useCallback, createContext, useContext } from "react";
 
-type ToastType = "success" | "error" | "info";
+type ToastType = "success" | "error" | "info" | "warning";
 
 interface Toast {
   id: number;
   message: string;
   type: ToastType;
+  duration: number;
+  action?: { label: string; onClick: () => void };
+}
+
+interface ToastOptions {
+  type?: ToastType;
+  duration?: number;
+  action?: { label: string; onClick: () => void };
 }
 
 interface ToastContextValue {
-  toast: (message: string, type?: ToastType) => void;
+  toast: (message: string, options?: ToastType | ToastOptions) => void;
 }
 
 const ToastContext = createContext<ToastContextValue>({
@@ -20,15 +28,30 @@ export function useToast() {
   return useContext(ToastContext);
 }
 
+const DEFAULT_DURATION = 3000;
 let nextId = 0;
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
-  const addToast = useCallback((message: string, type: ToastType = "info") => {
-    const id = nextId++;
-    setToasts((prev) => [...prev, { id, message, type }]);
-  }, []);
+  const addToast = useCallback(
+    (message: string, options?: ToastType | ToastOptions) => {
+      const id = nextId++;
+      const opts: ToastOptions =
+        typeof options === "string" ? { type: options } : options ?? {};
+      setToasts((prev) => [
+        ...prev,
+        {
+          id,
+          message,
+          type: opts.type ?? "info",
+          duration: opts.duration ?? DEFAULT_DURATION,
+          action: opts.action,
+        },
+      ]);
+    },
+    [],
+  );
 
   const removeToast = useCallback((id: number) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
@@ -50,6 +73,7 @@ const typeStyles: Record<ToastType, string> = {
   success: "border-green-500/30 bg-green-500/10 text-green-400",
   error: "border-red-500/30 bg-red-500/10 text-red-400",
   info: "border-lofi-accent/30 bg-lofi-accent/10 text-lofi-accent",
+  warning: "border-yellow-500/30 bg-yellow-500/10 text-yellow-400",
 };
 
 function ToastItem({
@@ -68,20 +92,31 @@ function ToastItem({
     const timer = setTimeout(() => {
       setVisible(false);
       setTimeout(() => onDismiss(toast.id), 200);
-    }, 3000);
+    }, toast.duration);
 
     return () => clearTimeout(timer);
-  }, [toast.id, onDismiss]);
+  }, [toast.id, toast.duration, onDismiss]);
 
   return (
     <div
-      className={`rounded-sm border px-4 py-2 text-xs font-medium shadow-lg backdrop-blur-sm transition-all duration-200 ${typeStyles[toast.type]} ${
+      className={`flex items-center gap-3 rounded-sm border px-4 py-2 text-xs font-medium shadow-lg backdrop-blur-sm transition-all duration-200 ${typeStyles[toast.type]} ${
         visible
           ? "translate-x-0 opacity-100"
           : "translate-x-4 opacity-0"
       }`}
     >
-      {toast.message}
+      <span>{toast.message}</span>
+      {toast.action && (
+        <button
+          onClick={() => {
+            toast.action!.onClick();
+            onDismiss(toast.id);
+          }}
+          className="ml-auto shrink-0 underline underline-offset-2 hover:opacity-80"
+        >
+          {toast.action.label}
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/use-coach.ts
+++ b/frontend/src/hooks/use-coach.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { coachClient } from "@/lib/transport";
+
+export function useGetMatchAnalysis(matchId: string, puuid: string) {
+  return useQuery({
+    queryKey: ["coachMatchAnalysis", matchId, puuid],
+    queryFn: () => coachClient.getMatchAnalysis({ matchId, puuid }),
+    enabled: !!matchId && !!puuid,
+    staleTime: Infinity,
+  });
+}
+
+export function useAnalyzeMatch() {
+  return useMutation({
+    mutationFn: (params: { matchId: string; puuid: string; force?: boolean }) =>
+      coachClient.analyzeMatch(params),
+  });
+}
+
+export function useAnalyzeHistory() {
+  return useMutation({
+    mutationFn: (params: { puuid: string; matchCount?: number }) =>
+      coachClient.analyzeHistory(params),
+  });
+}

--- a/frontend/src/hooks/use-tier-list.ts
+++ b/frontend/src/hooks/use-tier-list.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { tierListClient } from "@/lib/transport";
+
+export function useTierList(patch = "", tierFilter = "") {
+  return useQuery({
+    queryKey: ["tierList", patch, tierFilter],
+    queryFn: () =>
+      tierListClient.getConsolidatedTierList({ patch, tierFilter }),
+    staleTime: 10 * 60 * 1000, // 10 minutes
+    retry: 1,
+  });
+}

--- a/frontend/src/lib/transport.ts
+++ b/frontend/src/lib/transport.ts
@@ -4,6 +4,7 @@ import { PatchService } from "@/gen/tft/v1/patch_pb";
 import { PlayerService } from "@/gen/tft/v1/player_pb";
 import { AuthService } from "@/gen/tft/v1/auth_pb";
 import { SimulationService } from "@/gen/tft/v1/simulation_pb";
+import { TierListService } from "@/gen/tft/v1/tierlist_pb";
 
 export const transport = createConnectTransport({
   baseUrl: "http://localhost:8080",
@@ -29,3 +30,4 @@ export const patchClient = createClient(PatchService, transport);
 export const playerClient = createClient(PlayerService, transport);
 export const authClient = createClient(AuthService, transport);
 export const simulationClient = createClient(SimulationService, transport);
+export const tierListClient = createClient(TierListService, transport);

--- a/frontend/src/lib/transport.ts
+++ b/frontend/src/lib/transport.ts
@@ -5,6 +5,7 @@ import { PlayerService } from "@/gen/tft/v1/player_pb";
 import { AuthService } from "@/gen/tft/v1/auth_pb";
 import { SimulationService } from "@/gen/tft/v1/simulation_pb";
 import { TierListService } from "@/gen/tft/v1/tierlist_pb";
+import { CoachService } from "@/gen/tft/v1/coach_pb";
 
 export const transport = createConnectTransport({
   baseUrl: "http://localhost:8080",
@@ -31,3 +32,4 @@ export const playerClient = createClient(PlayerService, transport);
 export const authClient = createClient(AuthService, transport);
 export const simulationClient = createClient(SimulationService, transport);
 export const tierListClient = createClient(TierListService, transport);
+export const coachClient = createClient(CoachService, transport);

--- a/frontend/src/pages/augments.tsx
+++ b/frontend/src/pages/augments.tsx
@@ -4,6 +4,8 @@ import { SectionHeader } from "@/components/layout/section-header";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { AugmentCard } from "@/components/augment-card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { InlineError } from "@/components/ui/inline-error";
+import { friendlyError } from "@/lib/error";
 
 const tierFilters = [
   { label: "silver", value: "silver" },
@@ -22,7 +24,7 @@ function getAugmentTier(tags: string[]): string | null {
 }
 
 export function AugmentsPage() {
-  const { data, isLoading, error } = usePatchData();
+  const { data, isLoading, error, refetch } = usePatchData();
   const [search, setSearch] = useState("");
   const [tierFilter, setTierFilter] = useState("all");
 
@@ -44,8 +46,9 @@ export function AugmentsPage() {
 
   if (error) {
     return (
-      <div className="text-xs text-red-400">
-        error: {error.message}
+      <div>
+        <SectionHeader number="05" title="augments" />
+        <InlineError message={friendlyError(error)} onRetry={() => refetch()} />
       </div>
     );
   }

--- a/frontend/src/pages/champions.tsx
+++ b/frontend/src/pages/champions.tsx
@@ -4,6 +4,8 @@ import { SectionHeader } from "@/components/layout/section-header";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ChampionCard } from "@/components/champion-card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { InlineError } from "@/components/ui/inline-error";
+import { friendlyError } from "@/lib/error";
 
 const costFilters = [
   { label: "1g", value: "1" },
@@ -14,7 +16,7 @@ const costFilters = [
 ];
 
 export function ChampionsPage() {
-  const { data, isLoading, error } = usePatchData();
+  const { data, isLoading, error, refetch } = usePatchData();
   const [search, setSearch] = useState("");
   const [costFilter, setCostFilter] = useState("all");
 
@@ -41,8 +43,9 @@ export function ChampionsPage() {
 
   if (error) {
     return (
-      <div className="text-xs text-red-400">
-        error: {error.message}
+      <div>
+        <SectionHeader number="01" title="champions" />
+        <InlineError message={friendlyError(error)} onRetry={() => refetch()} />
       </div>
     );
   }

--- a/frontend/src/pages/coach.tsx
+++ b/frontend/src/pages/coach.tsx
@@ -1,0 +1,197 @@
+import { useState } from "react";
+import { usePlayerProfile } from "@/hooks/use-player-profile";
+import { useMatchHistory } from "@/hooks/use-match-history";
+import { usePatchLookup } from "@/hooks/use-patch-lookup";
+import { useAuthStore } from "@/stores/auth-store";
+import { useCurrentUser } from "@/hooks/use-auth";
+import { SectionHeader } from "@/components/layout/section-header";
+import { ProfileHeader } from "@/components/player/profile-header";
+import { PlacementBadge } from "@/components/player/placement-badge";
+import { UnitIcon } from "@/components/player/unit-icon";
+import { TraitBadge } from "@/components/player/trait-badge";
+import { MatchDetailScreen } from "@/components/coach/match-detail-screen";
+import { TerminalCard } from "@/components/ui/terminal-card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AuthGate } from "@/components/auth/auth-gate";
+import type { Match } from "@/gen/tft/v1/player_pb";
+import type { PatchLookup } from "@/hooks/use-patch-lookup";
+
+export function CoachPage() {
+  const { user } = useAuthStore();
+  const currentUser = useCurrentUser();
+  const [selectedMatch, setSelectedMatch] = useState<Match | null>(null);
+
+  const authUser = currentUser.data?.user ?? user;
+  const gameName = authUser?.gameName ?? "";
+  const tagLine = authUser?.tagLine ?? "";
+  const region = authUser?.region ?? "";
+  const puuid = authUser?.puuid ?? "";
+
+  const profile = usePlayerProfile(gameName, tagLine, region);
+  const matchHistory = useMatchHistory(puuid, region);
+  const patchLookup = usePatchLookup();
+
+  const hasMatches =
+    matchHistory.data?.matches && matchHistory.data.matches.length > 0;
+
+  return (
+    <div>
+      <SectionHeader number="07" title="ai coach" />
+
+      <AuthGate>
+        {/* Loading */}
+        {currentUser.isLoading && (
+          <div className="space-y-3">
+            <Skeleton className="h-20" />
+            <Skeleton className="h-48" />
+          </div>
+        )}
+
+        {/* ── Match Detail Screen ── */}
+        {selectedMatch && patchLookup ? (
+          <MatchDetailScreen
+            match={selectedMatch}
+            playerPuuid={puuid}
+            patchLookup={patchLookup}
+            onBack={() => setSelectedMatch(null)}
+          />
+        ) : (
+          <>
+            {/* Profile */}
+            {profile.data?.account && (
+              <div className="mb-4">
+                <ProfileHeader
+                  account={profile.data.account}
+                  summoner={profile.data.summoner}
+                  rankedEntries={profile.data.rankedEntries}
+                />
+              </div>
+            )}
+
+            {/* Match History List */}
+            {matchHistory.isLoading && !currentUser.isLoading && (
+              <div className="space-y-2">
+                {[1, 2, 3].map((i) => (
+                  <Skeleton key={i} className="h-16 w-full" />
+                ))}
+              </div>
+            )}
+
+            {hasMatches && patchLookup && (
+              <div className="space-y-1.5">
+                <p className="text-xs font-medium uppercase text-lofi-muted">
+                  match history — click to view details
+                </p>
+                {matchHistory.data!.matches.map((match) => (
+                  <MatchRow
+                    key={match.metadata?.matchId}
+                    match={match}
+                    playerPuuid={puuid}
+                    patchLookup={patchLookup}
+                    onClick={() => setSelectedMatch(match)}
+                  />
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </AuthGate>
+    </div>
+  );
+}
+
+// ── Clickable match row ──
+
+function MatchRow({
+  match,
+  playerPuuid,
+  patchLookup,
+  onClick,
+}: {
+  match: Match;
+  playerPuuid: string;
+  patchLookup: PatchLookup;
+  onClick: () => void;
+}) {
+  const info = match.info;
+  if (!info) return null;
+
+  const player = info.participants.find((p) => p.puuid === playerPuuid);
+  if (!player) return null;
+
+  const gameDate = new Date(Number(info.gameDatetime));
+  const timeAgo = getTimeAgo(gameDate);
+  const gameLengthMin = (info.gameLength / 60).toFixed(0);
+
+  const activeTraits = player.traits
+    .filter((t) => t.style > 0)
+    .sort((a, b) => b.style - a.style);
+  const sortedUnits = [...player.units].sort(
+    (a, b) => b.rarity - a.rarity || b.tier - a.tier,
+  );
+
+  return (
+    <TerminalCard
+      className={`cursor-pointer transition-colors hover:border-lofi-muted ${
+        player.placement <= 4
+          ? "border-l-2 border-l-green-500/40"
+          : "border-l-2 border-l-red-500/30"
+      }`}
+    >
+      <div onClick={onClick} className="space-y-2">
+        {/* Top row: placement + info + button */}
+        <div className="flex items-center gap-4">
+          <PlacementBadge placement={player.placement} size="md" className="shrink-0" />
+
+          <div className="min-w-0 flex-1 space-y-0.5">
+            <div className="flex items-center gap-3 text-xs text-lofi-muted">
+              <span>{timeAgo}</span>
+              <span>{gameLengthMin}m</span>
+              <span>lv{player.level}</span>
+              <span>{player.goldLeft}g</span>
+              <span>⚔ {player.totalDamageToPlayers}</span>
+              {player.playersEliminated > 0 && (
+                <span className="font-medium text-red-400">
+                  {player.playersEliminated} kill{player.playersEliminated > 1 ? "s" : ""}
+                </span>
+              )}
+            </div>
+
+            {/* Traits */}
+            <div className="flex flex-wrap gap-0.5">
+              {activeTraits.slice(0, 8).map((trait) => (
+                <TraitBadge
+                  key={trait.apiName}
+                  trait={trait}
+                  lookup={patchLookup}
+                />
+              ))}
+            </div>
+          </div>
+
+          <button className="shrink-0 rounded-sm border border-lofi-accent px-4 py-2 text-xs font-medium text-lofi-accent transition-colors hover:bg-lofi-accent hover:text-lofi-bg">
+            view details
+          </button>
+        </div>
+
+        {/* Bottom row: units */}
+        <div className="flex items-start gap-1.5 overflow-x-auto pl-[60px]">
+          {sortedUnits.map((unit, i) => (
+            <UnitIcon key={i} unit={unit} lookup={patchLookup} />
+          ))}
+        </div>
+      </div>
+    </TerminalCard>
+  );
+}
+
+function getTimeAgo(date: Date): string {
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/frontend/src/pages/items.tsx
+++ b/frontend/src/pages/items.tsx
@@ -4,6 +4,8 @@ import { SectionHeader } from "@/components/layout/section-header";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ItemCard } from "@/components/item-card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { InlineError } from "@/components/ui/inline-error";
+import { friendlyError } from "@/lib/error";
 
 const typeFilters = [
   { label: "component", value: "component" },
@@ -11,7 +13,7 @@ const typeFilters = [
 ];
 
 export function ItemsPage() {
-  const { data, isLoading, error } = usePatchData();
+  const { data, isLoading, error, refetch } = usePatchData();
   const [search, setSearch] = useState("");
   const [typeFilter, setTypeFilter] = useState("all");
 
@@ -35,8 +37,9 @@ export function ItemsPage() {
 
   if (error) {
     return (
-      <div className="text-xs text-red-400">
-        error: {error.message}
+      <div>
+        <SectionHeader number="02" title="items" />
+        <InlineError message={friendlyError(error)} onRetry={() => refetch()} />
       </div>
     );
   }

--- a/frontend/src/pages/simulator.tsx
+++ b/frontend/src/pages/simulator.tsx
@@ -19,6 +19,7 @@ import { ItemSelector } from "@/components/simulator/item-selector";
 import { SimulationResults } from "@/components/simulator/simulation-results";
 import { useSimulateBattle } from "@/hooks/use-simulate-battle";
 import { Button } from "@/components/ui/button";
+import { AuthGate } from "@/components/auth/auth-gate";
 
 export function SimulatorPage() {
   const { data, isLoading, error } = usePatchData();
@@ -83,6 +84,8 @@ export function SimulatorPage() {
     <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
       <div>
         <SectionHeader number="07" title="simulator" />
+
+        <AuthGate>
 
         <BoardControls />
 
@@ -182,6 +185,7 @@ export function SimulatorPage() {
             </div>
           </>
         )}
+        </AuthGate>
       </div>
     </DndContext>
   );

--- a/frontend/src/pages/tier-list.tsx
+++ b/frontend/src/pages/tier-list.tsx
@@ -1,0 +1,138 @@
+import { useState, useMemo } from "react";
+import { useTierList } from "@/hooks/use-tier-list";
+import { usePatchData } from "@/hooks/use-patch-data";
+import { SectionHeader } from "@/components/layout/section-header";
+import { SearchFilterBar } from "@/components/search-filter-bar";
+import { TierSection } from "@/components/tier-list/tier-section";
+import { TierListSkeleton } from "@/components/tier-list/tier-list-skeleton";
+import { CrawlStatusFooter } from "@/components/tier-list/crawl-status-footer";
+import { InlineError } from "@/components/ui/inline-error";
+import { GenericEmptyState } from "@/components/ui/generic-empty-state";
+import { friendlyError } from "@/lib/error";
+import type { TierListEntry } from "@/gen/tft/v1/tierlist_pb";
+import type { Champion, Item } from "@/gen/tft/v1/patch_pb";
+
+const tierFilters = [
+  { label: "S", value: "S" },
+  { label: "A", value: "A" },
+  { label: "B", value: "B" },
+  { label: "C", value: "C" },
+];
+
+const TIER_ORDER = ["S", "A", "B", "C", "D"];
+
+export function TierListPage() {
+  const { data, isLoading, error, refetch } = useTierList();
+  const { data: patchData } = usePatchData();
+  const [search, setSearch] = useState("");
+  const [tierFilter, setTierFilter] = useState("all");
+
+  // Build lookup maps from patch data
+  const championMap = useMemo(() => {
+    const map = new Map<string, Champion>();
+    for (const c of patchData?.champions ?? []) {
+      map.set(c.apiName, c);
+    }
+    return map;
+  }, [patchData?.champions]);
+
+  const itemMap = useMemo(() => {
+    const map = new Map<string, Item>();
+    for (const i of patchData?.items ?? []) {
+      map.set(i.apiName, i);
+    }
+    return map;
+  }, [patchData?.items]);
+
+  // Filter entries
+  const filtered = useMemo(() => {
+    const entries = data?.entries ?? [];
+    return entries.filter((e) => {
+      const matchesTier =
+        tierFilter === "all" || e.consolidatedTier === tierFilter;
+      const matchesSearch =
+        !search ||
+        e.compositionName.toLowerCase().includes(search.toLowerCase()) ||
+        e.coreChampions.some((id) => {
+          const champ = championMap.get(id);
+          return champ?.name.toLowerCase().includes(search.toLowerCase());
+        });
+      return matchesTier && matchesSearch;
+    });
+  }, [data?.entries, tierFilter, search, championMap]);
+
+  // Group by tier
+  const groupedByTier = useMemo(() => {
+    const groups = new Map<string, TierListEntry[]>();
+    for (const tier of TIER_ORDER) {
+      groups.set(tier, []);
+    }
+    for (const entry of filtered) {
+      const list = groups.get(entry.consolidatedTier);
+      if (list) {
+        list.push(entry);
+      }
+    }
+    return groups;
+  }, [filtered]);
+
+  if (error) {
+    return (
+      <div>
+        <SectionHeader number="08" title="tier list" />
+        <InlineError message={friendlyError(error)} onRetry={() => refetch()} />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <SectionHeader number="08" title="tier list" />
+
+      <SearchFilterBar
+        searchValue={search}
+        onSearchChange={setSearch}
+        searchPlaceholder="search compositions or champions..."
+        filters={tierFilters}
+        activeFilter={tierFilter}
+        onFilterChange={setTierFilter}
+      />
+
+      {isLoading ? (
+        <TierListSkeleton />
+      ) : filtered.length === 0 ? (
+        <GenericEmptyState
+          title="NO_DATA"
+          description="no compositions found. the crawler may not have run yet, or no results match your filters."
+          actionLabel="clear filters"
+          onAction={() => {
+            setSearch("");
+            setTierFilter("all");
+          }}
+        />
+      ) : (
+        <>
+          <p className="mb-4 text-[10px] text-lofi-muted">
+            {filtered.length} composition{filtered.length !== 1 ? "s" : ""}
+            {data?.patch ? ` // patch ${data.patch}` : ""}
+          </p>
+
+          {TIER_ORDER.map((tier) => {
+            const entries = groupedByTier.get(tier) ?? [];
+            return (
+              <TierSection
+                key={tier}
+                tier={tier}
+                entries={entries}
+                championMap={championMap}
+                itemMap={itemMap}
+              />
+            );
+          })}
+
+          <CrawlStatusFooter lastUpdated={data?.lastUpdated ?? ""} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -20,6 +20,11 @@
   /* Font family */
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono",
     Menlo, Consolas, monospace;
+
+  /* Animation timing */
+  --duration-fast: 100ms;
+  --duration-normal: 200ms;
+  --duration-slow: 300ms;
 }
 
 /* Light theme — override lofi palette CSS variables */

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,6 +16,19 @@ export default defineConfig({
   },
   build: {
     outDir: "dist",
-    sourcemap: true,
+    sourcemap: false,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ["react", "react-dom", "react-router-dom"],
+          query: ["@tanstack/react-query"],
+          connect: [
+            "@connectrpc/connect",
+            "@connectrpc/connect-web",
+            "@bufbuild/protobuf",
+          ],
+        },
+      },
+    },
   },
 });

--- a/migrations/000011_create_raw_tier_data.down.sql
+++ b/migrations/000011_create_raw_tier_data.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS raw_tier_data;

--- a/migrations/000011_create_raw_tier_data.up.sql
+++ b/migrations/000011_create_raw_tier_data.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE raw_tier_data (
+    id               SERIAL PRIMARY KEY,
+    source           VARCHAR(50) NOT NULL,
+    patch            VARCHAR(20) NOT NULL,
+    composition_name VARCHAR(255) NOT NULL,
+    tier             VARCHAR(5),
+    win_rate         DECIMAL(5,2),
+    play_rate        DECIMAL(5,2),
+    avg_placement    DECIMAL(3,2),
+    champion_ids     TEXT[] NOT NULL DEFAULT '{}',
+    core_items       JSONB NOT NULL DEFAULT '{}',
+    scraped_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_raw_tier_source ON raw_tier_data(source);
+CREATE INDEX idx_raw_tier_patch ON raw_tier_data(patch);
+CREATE INDEX idx_raw_tier_source_patch ON raw_tier_data(source, patch);

--- a/migrations/000012_create_consolidated_tier_list.down.sql
+++ b/migrations/000012_create_consolidated_tier_list.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS consolidated_tier_list;

--- a/migrations/000012_create_consolidated_tier_list.up.sql
+++ b/migrations/000012_create_consolidated_tier_list.up.sql
@@ -1,0 +1,22 @@
+CREATE TABLE consolidated_tier_list (
+    id                  SERIAL PRIMARY KEY,
+    patch               VARCHAR(20) NOT NULL,
+    composition_name    VARCHAR(255) NOT NULL,
+    consolidated_tier   VARCHAR(5) NOT NULL,
+    consolidated_score  DECIMAL(5,2) NOT NULL,
+    confidence          VARCHAR(20) NOT NULL DEFAULT 'low',
+    consensus           VARCHAR(30) NOT NULL DEFAULT 'unknown',
+    metatft_tier        VARCHAR(5),
+    tftactics_tier      VARCHAR(5),
+    mobalytics_tier     VARCHAR(5),
+    avg_win_rate        DECIMAL(5,2),
+    avg_play_rate       DECIMAL(5,2),
+    avg_placement       DECIMAL(3,2),
+    core_champions      TEXT[] NOT NULL DEFAULT '{}',
+    recommended_items   JSONB NOT NULL DEFAULT '{}',
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (patch, composition_name)
+);
+
+CREATE INDEX idx_consolidated_patch ON consolidated_tier_list(patch);
+CREATE INDEX idx_consolidated_tier ON consolidated_tier_list(consolidated_tier);

--- a/migrations/000013_create_coach_analyses.down.sql
+++ b/migrations/000013_create_coach_analyses.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS coach_history_analyses;
+DROP TABLE IF EXISTS coach_match_analyses;

--- a/migrations/000013_create_coach_analyses.up.sql
+++ b/migrations/000013_create_coach_analyses.up.sql
@@ -1,0 +1,26 @@
+-- Coach analysis cache tables.
+-- Stores AI coaching results to avoid re-analyzing the same data.
+
+CREATE TABLE coach_match_analyses (
+    match_id    TEXT NOT NULL,
+    puuid       TEXT NOT NULL,
+    response    JSONB NOT NULL,
+    model       VARCHAR(50) NOT NULL DEFAULT 'gpt-4o-mini',
+    tokens_used INT NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (match_id, puuid)
+);
+
+CREATE TABLE coach_history_analyses (
+    puuid       TEXT NOT NULL,
+    match_count INT NOT NULL,
+    match_ids   TEXT[] NOT NULL DEFAULT '{}',
+    response    JSONB NOT NULL,
+    model       VARCHAR(50) NOT NULL DEFAULT 'gpt-4o-mini',
+    tokens_used INT NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (puuid, match_count)
+);
+
+CREATE INDEX idx_coach_match_puuid ON coach_match_analyses(puuid);
+CREATE INDEX idx_coach_history_created ON coach_history_analyses(created_at);

--- a/proto/tft/v1/coach.proto
+++ b/proto/tft/v1/coach.proto
@@ -1,0 +1,144 @@
+syntax = "proto3";
+
+package tft.v1;
+
+option go_package = "github.com/MeninoNias/tft-oracle/backend/gen/tft/v1;tftv1";
+
+// CoachService provides AI-powered post-game coaching analysis.
+service CoachService {
+  // GetMatchAnalysis returns a previously cached analysis (no AI call).
+  rpc GetMatchAnalysis(GetMatchAnalysisRequest) returns (GetMatchAnalysisResponse);
+  // AnalyzeMatch delivers personalized coaching for a single completed match.
+  rpc AnalyzeMatch(AnalyzeMatchRequest) returns (AnalyzeMatchResponse);
+  // AnalyzeHistory identifies patterns and trends across recent matches.
+  rpc AnalyzeHistory(AnalyzeHistoryRequest) returns (AnalyzeHistoryResponse);
+}
+
+// --- Per-match analysis ---
+
+message GetMatchAnalysisRequest {
+  string match_id = 1;
+  string puuid = 2;
+}
+
+message GetMatchAnalysisResponse {
+  // True if a cached analysis was found.
+  bool found = 1;
+  // The cached analysis (only set if found=true).
+  AnalyzeMatchResponse analysis = 2;
+}
+
+message AnalyzeMatchRequest {
+  string match_id = 1;
+  string puuid = 2;
+  // If true, skip cache and re-generate analysis.
+  bool force = 3;
+}
+
+message AnalyzeMatchResponse {
+  string match_id = 1;
+  int32 placement = 2;
+  // Letter grade: "S+", "S", "A+", "A", "B+", "B", "C+", "C", "D", "F".
+  string overall_grade = 3;
+  // 2-3 sentence coaching summary.
+  string summary = 4;
+  // Per-category coaching insights.
+  repeated CoachingInsight insights = 5;
+  // Comparison against current meta compositions.
+  MetaComparison meta_comparison = 6;
+  // Analysis of lobby context (contested comps, relative strength).
+  LobbyContext lobby_context = 7;
+  // Prioritized improvement suggestions.
+  repeated CoachSuggestion suggestions = 8;
+}
+
+message CoachingInsight {
+  // "composition", "itemization", "economy", "augments", or "adaptability".
+  string category = 1;
+  string title = 2;
+  string detail = 3;
+  // "good", "okay", or "poor".
+  string grade = 4;
+}
+
+message MetaComparison {
+  // Name of the closest meta composition.
+  string closest_meta_comp = 1;
+  // Tier of that composition: "S", "A", "B", "C", "D".
+  string meta_tier = 2;
+  // Champions missing from the ideal version of the comp.
+  repeated string missing_units = 3;
+  // Items that differ from BIS (Best in Slot).
+  repeated string suboptimal_items = 4;
+  // Free-text assessment of how close the board was to meta.
+  string assessment = 5;
+}
+
+message LobbyContext {
+  // Number of players running similar compositions.
+  int32 contested_count = 1;
+  // Assessment of overall lobby strength relative to this player.
+  string lobby_strength_assessment = 2;
+  // Details on which players contested and how.
+  repeated string contested_details = 3;
+}
+
+message CoachSuggestion {
+  string description = 1;
+  // "high", "medium", or "low".
+  string priority = 2;
+  // "composition", "itemization", "economy", "augments", or "adaptability".
+  string category = 3;
+}
+
+// --- Multi-match analysis ---
+
+message AnalyzeHistoryRequest {
+  string puuid = 1;
+  // Number of recent matches to analyze (default 20, max 50).
+  int32 match_count = 2;
+}
+
+message AnalyzeHistoryResponse {
+  int32 matches_analyzed = 1;
+  // Overall coaching summary across all analyzed matches.
+  string overall_summary = 2;
+  // Skill ratings across 5 dimensions (0-100 each).
+  SkillRadar skill_radar = 3;
+  // Recurring patterns detected across matches.
+  repeated PatternInsight patterns = 4;
+  // Performance trends (improving, stable, declining).
+  repeated TrendItem trends = 5;
+  // Top 3-5 prioritized improvement actions.
+  repeated CoachSuggestion improvement_plan = 6;
+}
+
+message SkillRadar {
+  // Economy management: leveling, gold management, loss/win-streaking.
+  float economy = 1;
+  // Item optimization: BIS choices, slam timing, component usage.
+  float itemization = 2;
+  // Composition quality: meta awareness, comp completeness, unit quality.
+  float composition = 3;
+  // Adaptability: flexibility, pivoting, not forcing comps.
+  float adaptability = 4;
+  // Consistency: placement variance, avoiding 8ths, steady top-4 rate.
+  float consistency = 5;
+}
+
+message PatternInsight {
+  // "composition", "itemization", "economy", "augments", or "adaptability".
+  string category = 1;
+  string title = 2;
+  string detail = 3;
+  // "positive", "neutral", or "negative".
+  string sentiment = 4;
+}
+
+message TrendItem {
+  // What metric is trending (e.g., "average placement", "top 4 rate").
+  string metric = 1;
+  // "improving", "stable", or "declining".
+  string direction = 2;
+  string detail = 3;
+}

--- a/proto/tft/v1/tierlist.proto
+++ b/proto/tft/v1/tierlist.proto
@@ -1,0 +1,80 @@
+syntax = "proto3";
+
+package tft.v1;
+
+option go_package = "github.com/MeninoNias/tft-oracle/backend/gen/tft/v1;tftv1";
+
+// TierListService provides cross-source consolidated tier list data.
+service TierListService {
+  // GetConsolidatedTierList returns the merged tier list for a patch.
+  rpc GetConsolidatedTierList(GetConsolidatedTierListRequest) returns (GetConsolidatedTierListResponse);
+  // TriggerCrawl manually triggers a crawl cycle.
+  rpc TriggerCrawl(TriggerCrawlRequest) returns (TriggerCrawlResponse);
+  // GetCrawlerStatus returns the last crawl timestamps and per-source status.
+  rpc GetCrawlerStatus(GetCrawlerStatusRequest) returns (GetCrawlerStatusResponse);
+}
+
+message GetConsolidatedTierListRequest {
+  // Patch version (e.g. "14.10"). Empty = latest available.
+  string patch = 1;
+  // Filter by tier (e.g. "S"). Empty = all tiers.
+  string tier_filter = 2;
+}
+
+message GetConsolidatedTierListResponse {
+  string patch = 1;
+  repeated TierListEntry entries = 2;
+  // ISO 8601 timestamp of last consolidation.
+  string last_updated = 3;
+}
+
+message TierListEntry {
+  string composition_name = 1;
+  // Consolidated tier: "S", "A", "B", "C", "D".
+  string consolidated_tier = 2;
+  // Numeric score (0-100).
+  double consolidated_score = 3;
+  // "high", "medium", "low".
+  string confidence = 4;
+  // "unanimous", "majority", "split", "single_source".
+  string consensus = 5;
+  // Per-source tiers (empty string if source didn't have this comp).
+  string metatft_tier = 6;
+  string tftactics_tier = 7;
+  string mobalytics_tier = 8;
+  // Consolidated stats.
+  double avg_win_rate = 9;
+  double avg_play_rate = 10;
+  double avg_placement = 11;
+  // Champion api_names in this composition.
+  repeated string core_champions = 12;
+  // Recommended items per champion: champion_api_name -> item list.
+  map<string, ItemList> recommended_items = 13;
+}
+
+message ItemList {
+  repeated string item_api_names = 1;
+}
+
+message TriggerCrawlRequest {}
+
+message TriggerCrawlResponse {
+  string message = 1;
+}
+
+message GetCrawlerStatusRequest {}
+
+message GetCrawlerStatusResponse {
+  repeated SourceStatus sources = 1;
+  // ISO 8601 timestamp of last consolidation run.
+  string last_consolidation = 2;
+}
+
+message SourceStatus {
+  string source = 1;
+  // ISO 8601 timestamp of last successful scrape.
+  string last_scraped = 2;
+  // "ok", "error", "never".
+  string status = 3;
+  string error_message = 4;
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,9 +1,16 @@
 [package]
 name = "tft-oracle"
-version = "0.1.0"
+version = "0.4.0"
 description = "TFT Oracle — AI-powered TFT coach"
 authors = ["MeninoNias"]
 edition = "2021"
+
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1
+opt-level = "s"
+panic = "abort"
 
 [lib]
 name = "tft_oracle_lib"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "TFT Oracle",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "identifier": "com.tft-oracle.app",
   "build": {
     "frontendDist": "../frontend/dist",
@@ -15,6 +15,8 @@
         "title": "TFT Oracle",
         "width": 1200,
         "height": 800,
+        "minWidth": 800,
+        "minHeight": 600,
         "resizable": true,
         "fullscreen": false
       }
@@ -22,5 +24,15 @@
     "security": {
       "csp": "default-src 'self'; connect-src 'self' http://localhost:8080; img-src 'self' https://raw.communitydragon.org data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com"
     }
+  },
+  "bundle": {
+    "active": true,
+    "targets": ["msi", "nsis"],
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.ico"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- **CoachService** with 3 RPCs: `GetMatchAnalysis` (cache read), `AnalyzeMatch` (AI coaching), `AnalyzeHistory` (multi-match patterns)
- Post-game AI coaching using GPT-4o-mini with structured outputs — grade, insights per category, meta comparison, lobby analysis, and actionable suggestions
- DB-backed cache (`coach_match_analyses`, `coach_history_analyses`) with `force` flag for re-generation
- Auth-gated: both Coach and Simulator services now require authentication
- Dedicated Coach page with match detail screen, skill radar chart, and history analysis
- Sidebar redesign: user profile card at top, AI Coach as first nav item

## What's new

### Backend (Go)
- `proto/tft/v1/coach.proto` — CoachService contract
- `backend/internal/coach/` — service + mapper (cache → enrich → prompt → OpenAI → response)
- `backend/internal/ai/coach_prompt.go` — coaching prompts with lobby context, meta tier list, rank calibration
- `backend/internal/ai/coach_schema.go` — JSON schemas + system prompts for structured outputs
- `migrations/000013_*` — cache tables for coaching results
- `auth.RequireAuth` added to SimulationService and CoachService

### Frontend (React)
- `/coach` page — auth-only, auto-loads logged-in user's matches
- Match detail screen — full board view + augments + traits + lobby + "analyze match" button
- Auto-loads cached analysis on revisit, "re-analyze" for fresh AI call
- Skill radar SVG chart (economy, itemization, composition, adaptability, consistency)
- `AuthGate` component for Coach and Simulator pages
- Sidebar: user profile card above nav, reordered items (AI Coach first)

## Test plan
- [ ] `cd backend && go build ./cmd/server` — compiles
- [ ] `cd backend && go test ./internal/ai/...` — 14 tests pass
- [ ] `cd frontend && npm run build` — TypeScript + Vite build clean
- [ ] Login → navigate to AI Coach → see match history
- [ ] Click match → see detail screen with board/lobby
- [ ] Click "analyze match" → AI coaching appears with grade + insights
- [ ] Revisit same match → cached analysis loads instantly
- [ ] Click "re-analyze" → fresh AI call replaces cached result
- [ ] Unauthenticated user → sees "authentication required" on Coach and Simulator

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)